### PR TITLE
Allow to override CC and AR for cross compilation.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::env;
 
 fn main() {
     assert!(Command::new("make")
-        .args(&["-f", "makefile.cargo", &format!("-j{}", env::var("NUM_JOBS").unwrap())])
+        .args(&["-R", "-f", "makefile.cargo", &format!("-j{}", env::var("NUM_JOBS").unwrap())])
         .status()
         .unwrap()
         .success());

--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,7 +1,7 @@
 ifeq (eabi,$(findstring eabi,$(TARGET)))
 
-CC := $(TARGET)-gcc
-AR := $(TARGET)-ar
+CC ?= $(TARGET)-gcc
+AR ?= $(TARGET)-ar
 
 else
 


### PR DESCRIPTION
In some cases cross compilation fails with harfbuzz, this fixes the issue. 
Part of servo/servo#6327

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/50)
<!-- Reviewable:end -->
