### PR TITLE
Revert "Move touch command into makefile.cargo"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
  - stable
  - nightly
 script:
+ - touch harfbuzz-sys/harfbuzz/{configure.ac,aclocal.m4,configure,Makefile.am,Makefile.in}
  - cargo build --verbose --manifest-path=harfbuzz-sys/Cargo.toml
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,16 +1,6 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.1.3"
-
-# Ignore timestamps on automake-generated files. See comment in makefile.cargo.
-exclude = [
-    "harfbuzz/configure.ac",
-    "harfbuzz/aclocal.m4",
-    "harfbuzz/configure",
-    "harfbuzz/config.h.in",
-    "harfbuzz/Makefile.am",
-    "harfbuzz/Makefile.in",
-]
+version = "0.1.4"
 
 authors = ["The Servo Project Developers"]
 license = "MIT"

--- a/harfbuzz-sys/makefile.cargo
+++ b/harfbuzz-sys/makefile.cargo
@@ -28,21 +28,9 @@ CONFIGURE_FLAGS = \
 	--without-glib
 
 all:
-	touch $(AUTOMAKE_FILES)
 	cd $(OUT_DIR) && $(CARGO_MANIFEST_DIR)/harfbuzz/configure $(CONFIGURE_FLAGS) \
 		CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
 	cd $(OUT_DIR) && make -j$(NUM_JOBS)
 	cd $(OUT_DIR) && make install
-
-# If the timestamp on these files is incorrect (because git does not preserve timestamps)
-# then the configure script will incorrectly try to run automake commands to regenerate them.
-# We `touch` these files to prevent this.
-AUTOMAKE_FILES = \
-	harfbuzz/configure.ac \
-	harfbuzz/aclocal.m4 \
-	harfbuzz/configure \
-	harfbuzz/config.h.in \
-	harfbuzz/Makefile.am \
-	harfbuzz/Makefile.in
 
 .PHONY: all


### PR DESCRIPTION
This reverts #58.  The patch worked fine when building from git but broke when published to crates.io, because `cargo publish` does not package files in the `exclude` list. :(

r? @metajack

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/60)
<!-- Reviewable:end -->
