### PR TITLE
Compile --with-coretext on apple-darwin (see servo/servo#4320)

### DIFF
--- a/harfbuzz-sys/makefile.cargo
+++ b/harfbuzz-sys/makefile.cargo
@@ -27,6 +27,10 @@ CONFIGURE_FLAGS = \
 	--without-freetype \
 	--without-glib
 
+ifeq ("apple-darwin",$(findstring "apple-darwin",$(TARGET)))
+	CONFIGURE_FLAGS += --with-coretext
+endif
+
 all:
 	cd $(OUT_DIR) && $(CARGO_MANIFEST_DIR)/harfbuzz/configure $(CONFIGURE_FLAGS) \
 		CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"


### PR DESCRIPTION
This enable support for mort and morx ligatures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/61)
<!-- Reviewable:end -->
