### PR TITLE
Set Cargo metadata so dependents can find hb.h

### DIFF
--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -31,4 +31,7 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", out_dir.join("lib").to_str().unwrap());
         println!("cargo:rustc-link-lib=static=harfbuzz");
     }
+
+    // Dependent crates that need to find hb.h can use DEP_HARFBUZZ_INCLUDE from their build.rs.
+    println!("cargo:include={}", env::current_dir().unwrap().join("harfbuzz/src").display());
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/73)
<!-- Reviewable:end -->
