### PR TITLE
README: Point to docs.rs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Build Status](https://travis-ci.org/servo/rust-harfbuzz.svg)](https://travis-ci.org/servo/rust-harfbuzz)
 
-[Documentation](http://doc.servo.org/harfbuzz_sys/)
+[Documentation](https://docs.rs/harfbuzz-sys/)
 
 Bindings to the Harfbuzz text shaping engine


### PR DESCRIPTION
The crate documentation link already points to docs.rs, so this
brings the README into line with that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/84)
<!-- Reviewable:end -->
