### PR TITLE
Fix non_snake_case warning in test.

### DIFF
--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -144,6 +144,7 @@ pub struct _hb_var_int_t {
     pub i8: __BindgenUnionField<[i8; 4usize]>,
     pub bindgen_union_field: u32,
 }
+#[allow(non_snake_case)]
 #[test]
 fn bindgen_test_layout__hb_var_int_t() {
     assert_eq!(::std::mem::size_of::<_hb_var_int_t>() , 4usize , concat ! (


### PR DESCRIPTION
This fixes the warning that shows up in `cargo test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/85)
<!-- Reviewable:end -->
