### PR TITLE
Disable clippy warning for unreadable_literal.

### DIFF
--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(non_camel_case_types)]
 
+#![cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
+
 #[cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))]
 extern crate freetype;
 


### PR DESCRIPTION
The code generated by bindgen doesn't follow this guideline, so we'll
disable that check here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/94)
<!-- Reviewable:end -->
