### PR TITLE
Use ::std::ptr::null instead of literal 0.

### DIFF
--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -81,7 +81,7 @@ fn bindgen_test_layout__hb_var_int_t() {
         concat!("Alignment of ", stringify!(_hb_var_int_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const _hb_var_int_t)).u32 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_hb_var_int_t>())).u32 as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -91,7 +91,7 @@ fn bindgen_test_layout__hb_var_int_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const _hb_var_int_t)).i32 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_hb_var_int_t>())).i32 as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -101,7 +101,7 @@ fn bindgen_test_layout__hb_var_int_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const _hb_var_int_t)).u16 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_hb_var_int_t>())).u16 as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -111,7 +111,7 @@ fn bindgen_test_layout__hb_var_int_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const _hb_var_int_t)).i16 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_hb_var_int_t>())).i16 as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -121,7 +121,7 @@ fn bindgen_test_layout__hb_var_int_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const _hb_var_int_t)).u8 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_hb_var_int_t>())).u8 as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -131,7 +131,7 @@ fn bindgen_test_layout__hb_var_int_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const _hb_var_int_t)).i8 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<_hb_var_int_t>())).i8 as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -367,7 +367,7 @@ fn bindgen_test_layout_hb_user_data_key_t() {
         concat!("Alignment of ", stringify!(hb_user_data_key_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_user_data_key_t)).unused as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_user_data_key_t>())).unused as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -400,7 +400,7 @@ fn bindgen_test_layout_hb_feature_t() {
         concat!("Alignment of ", stringify!(hb_feature_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_feature_t)).tag as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_feature_t>())).tag as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -410,7 +410,7 @@ fn bindgen_test_layout_hb_feature_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_feature_t)).value as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_feature_t>())).value as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -420,7 +420,7 @@ fn bindgen_test_layout_hb_feature_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_feature_t)).start as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_feature_t>())).start as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -430,7 +430,7 @@ fn bindgen_test_layout_hb_feature_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_feature_t)).end as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_feature_t>())).end as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -477,7 +477,7 @@ fn bindgen_test_layout_hb_variation_t() {
         concat!("Alignment of ", stringify!(hb_variation_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_variation_t)).tag as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_variation_t>())).tag as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -487,7 +487,7 @@ fn bindgen_test_layout_hb_variation_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_variation_t)).value as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_variation_t>())).value as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -1145,7 +1145,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         concat!("Alignment of ", stringify!(hb_font_extents_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).ascender as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).ascender as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -1155,7 +1155,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).descender as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).descender as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -1165,7 +1165,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).line_gap as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).line_gap as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -1175,7 +1175,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved9 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved9 as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -1185,7 +1185,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved8 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved8 as *const _ as usize },
         16usize,
         concat!(
             "Alignment of field: ",
@@ -1195,7 +1195,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved7 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved7 as *const _ as usize },
         20usize,
         concat!(
             "Alignment of field: ",
@@ -1205,7 +1205,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved6 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved6 as *const _ as usize },
         24usize,
         concat!(
             "Alignment of field: ",
@@ -1215,7 +1215,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved5 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved5 as *const _ as usize },
         28usize,
         concat!(
             "Alignment of field: ",
@@ -1225,7 +1225,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved4 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved4 as *const _ as usize },
         32usize,
         concat!(
             "Alignment of field: ",
@@ -1235,7 +1235,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved3 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved3 as *const _ as usize },
         36usize,
         concat!(
             "Alignment of field: ",
@@ -1245,7 +1245,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved2 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved2 as *const _ as usize },
         40usize,
         concat!(
             "Alignment of field: ",
@@ -1255,7 +1255,7 @@ fn bindgen_test_layout_hb_font_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_font_extents_t)).reserved1 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_font_extents_t>())).reserved1 as *const _ as usize },
         44usize,
         concat!(
             "Alignment of field: ",
@@ -1286,7 +1286,7 @@ fn bindgen_test_layout_hb_glyph_extents_t() {
         concat!("Alignment of ", stringify!(hb_glyph_extents_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_extents_t)).x_bearing as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_extents_t>())).x_bearing as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -1296,7 +1296,7 @@ fn bindgen_test_layout_hb_glyph_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_extents_t)).y_bearing as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_extents_t>())).y_bearing as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -1306,7 +1306,7 @@ fn bindgen_test_layout_hb_glyph_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_extents_t)).width as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_extents_t>())).width as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -1316,7 +1316,7 @@ fn bindgen_test_layout_hb_glyph_extents_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_extents_t)).height as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_extents_t>())).height as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -2020,7 +2020,7 @@ fn bindgen_test_layout_hb_glyph_info_t() {
         concat!("Alignment of ", stringify!(hb_glyph_info_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_info_t)).codepoint as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_info_t>())).codepoint as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -2030,7 +2030,7 @@ fn bindgen_test_layout_hb_glyph_info_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_info_t)).mask as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_info_t>())).mask as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -2040,7 +2040,7 @@ fn bindgen_test_layout_hb_glyph_info_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_info_t)).cluster as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_info_t>())).cluster as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -2050,7 +2050,7 @@ fn bindgen_test_layout_hb_glyph_info_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_info_t)).var1 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_info_t>())).var1 as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -2060,7 +2060,7 @@ fn bindgen_test_layout_hb_glyph_info_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_info_t)).var2 as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_info_t>())).var2 as *const _ as usize },
         16usize,
         concat!(
             "Alignment of field: ",
@@ -2105,7 +2105,7 @@ fn bindgen_test_layout_hb_glyph_position_t() {
         concat!("Alignment of ", stringify!(hb_glyph_position_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_position_t)).x_advance as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_position_t>())).x_advance as *const _ as usize },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -2115,7 +2115,7 @@ fn bindgen_test_layout_hb_glyph_position_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_position_t)).y_advance as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_position_t>())).y_advance as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -2125,7 +2125,7 @@ fn bindgen_test_layout_hb_glyph_position_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_position_t)).x_offset as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_position_t>())).x_offset as *const _ as usize },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -2135,7 +2135,7 @@ fn bindgen_test_layout_hb_glyph_position_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_position_t)).y_offset as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_position_t>())).y_offset as *const _ as usize },
         12usize,
         concat!(
             "Alignment of field: ",
@@ -2145,7 +2145,7 @@ fn bindgen_test_layout_hb_glyph_position_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_glyph_position_t)).var as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_glyph_position_t>())).var as *const _ as usize },
         16usize,
         concat!(
             "Alignment of field: ",
@@ -2185,7 +2185,9 @@ fn bindgen_test_layout_hb_segment_properties_t() {
         concat!("Alignment of ", stringify!(hb_segment_properties_t))
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_segment_properties_t)).direction as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<hb_segment_properties_t>())).direction as *const _ as usize
+        },
         0usize,
         concat!(
             "Alignment of field: ",
@@ -2195,7 +2197,7 @@ fn bindgen_test_layout_hb_segment_properties_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_segment_properties_t)).script as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<hb_segment_properties_t>())).script as *const _ as usize },
         4usize,
         concat!(
             "Alignment of field: ",
@@ -2205,7 +2207,9 @@ fn bindgen_test_layout_hb_segment_properties_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_segment_properties_t)).language as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<hb_segment_properties_t>())).language as *const _ as usize
+        },
         8usize,
         concat!(
             "Alignment of field: ",
@@ -2215,7 +2219,9 @@ fn bindgen_test_layout_hb_segment_properties_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_segment_properties_t)).reserved1 as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<hb_segment_properties_t>())).reserved1 as *const _ as usize
+        },
         16usize,
         concat!(
             "Alignment of field: ",
@@ -2225,7 +2231,9 @@ fn bindgen_test_layout_hb_segment_properties_t() {
         )
     );
     assert_eq!(
-        unsafe { &(*(0 as *const hb_segment_properties_t)).reserved2 as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<hb_segment_properties_t>())).reserved2 as *const _ as usize
+        },
         24usize,
         concat!(
             "Alignment of field: ",


### PR DESCRIPTION
This brings us up to how current versions of bindgen generate
this construct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/95)
<!-- Reviewable:end -->
