### PR TITLE
Add hb_ot_* bindings.

### DIFF
--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -14,6 +14,11 @@ extern "C" {
 
 pub const HB_UNICODE_MAX_DECOMPOSITION_LEN: ::std::os::raw::c_uint = 19;
 pub const HB_BUFFER_REPLACEMENT_CODEPOINT_DEFAULT: ::std::os::raw::c_uint = 65533;
+pub const HB_OT_LAYOUT_NO_SCRIPT_INDEX: ::std::os::raw::c_uint = 65535;
+pub const HB_OT_LAYOUT_NO_FEATURE_INDEX: ::std::os::raw::c_uint = 65535;
+pub const HB_OT_LAYOUT_DEFAULT_LANGUAGE_INDEX: ::std::os::raw::c_uint = 65535;
+pub const HB_OT_LAYOUT_NO_VARIATIONS_INDEX: ::std::os::raw::c_uint = 4294967295;
+pub const HB_OT_VAR_NO_AXIS_INDEX: ::std::os::raw::c_uint = 4294967295;
 pub type hb_bool_t = ::std::os::raw::c_int;
 pub type hb_codepoint_t = u32;
 pub type hb_position_t = i32;
@@ -2784,4 +2789,644 @@ extern "C" {
         minor: ::std::os::raw::c_uint,
         micro: ::std::os::raw::c_uint,
     ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_font_set_funcs(font: *mut hb_font_t);
+}
+extern "C" {
+    pub fn hb_ot_tags_from_script(
+        script: hb_script_t,
+        script_tag_1: *mut hb_tag_t,
+        script_tag_2: *mut hb_tag_t,
+    );
+}
+extern "C" {
+    pub fn hb_ot_tag_to_script(tag: hb_tag_t) -> hb_script_t;
+}
+extern "C" {
+    pub fn hb_ot_tag_from_language(language: hb_language_t) -> hb_tag_t;
+}
+extern "C" {
+    pub fn hb_ot_tag_to_language(tag: hb_tag_t) -> hb_language_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_has_glyph_classes(face: *mut hb_face_t) -> hb_bool_t;
+}
+pub const HB_OT_LAYOUT_GLYPH_CLASS_UNCLASSIFIED: hb_ot_layout_glyph_class_t = 0;
+pub const HB_OT_LAYOUT_GLYPH_CLASS_BASE_GLYPH: hb_ot_layout_glyph_class_t = 1;
+pub const HB_OT_LAYOUT_GLYPH_CLASS_LIGATURE: hb_ot_layout_glyph_class_t = 2;
+pub const HB_OT_LAYOUT_GLYPH_CLASS_MARK: hb_ot_layout_glyph_class_t = 3;
+pub const HB_OT_LAYOUT_GLYPH_CLASS_COMPONENT: hb_ot_layout_glyph_class_t = 4;
+pub type hb_ot_layout_glyph_class_t = ::std::os::raw::c_uint;
+extern "C" {
+    pub fn hb_ot_layout_get_glyph_class(
+        face: *mut hb_face_t,
+        glyph: hb_codepoint_t,
+    ) -> hb_ot_layout_glyph_class_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_get_glyphs_in_class(
+        face: *mut hb_face_t,
+        klass: hb_ot_layout_glyph_class_t,
+        glyphs: *mut hb_set_t,
+    );
+}
+extern "C" {
+    pub fn hb_ot_layout_get_attach_points(
+        face: *mut hb_face_t,
+        glyph: hb_codepoint_t,
+        start_offset: ::std::os::raw::c_uint,
+        point_count: *mut ::std::os::raw::c_uint,
+        point_array: *mut ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_get_ligature_carets(
+        font: *mut hb_font_t,
+        direction: hb_direction_t,
+        glyph: hb_codepoint_t,
+        start_offset: ::std::os::raw::c_uint,
+        caret_count: *mut ::std::os::raw::c_uint,
+        caret_array: *mut hb_position_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_table_get_script_tags(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        start_offset: ::std::os::raw::c_uint,
+        script_count: *mut ::std::os::raw::c_uint,
+        script_tags: *mut hb_tag_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_table_find_script(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_tag: hb_tag_t,
+        script_index: *mut ::std::os::raw::c_uint,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_table_choose_script(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_tags: *const hb_tag_t,
+        script_index: *mut ::std::os::raw::c_uint,
+        chosen_script: *mut hb_tag_t,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_table_get_feature_tags(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        start_offset: ::std::os::raw::c_uint,
+        feature_count: *mut ::std::os::raw::c_uint,
+        feature_tags: *mut hb_tag_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_script_get_language_tags(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        start_offset: ::std::os::raw::c_uint,
+        language_count: *mut ::std::os::raw::c_uint,
+        language_tags: *mut hb_tag_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_script_find_language(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        language_tag: hb_tag_t,
+        language_index: *mut ::std::os::raw::c_uint,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_language_get_required_feature_index(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        language_index: ::std::os::raw::c_uint,
+        feature_index: *mut ::std::os::raw::c_uint,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_language_get_required_feature(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        language_index: ::std::os::raw::c_uint,
+        feature_index: *mut ::std::os::raw::c_uint,
+        feature_tag: *mut hb_tag_t,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_language_get_feature_indexes(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        language_index: ::std::os::raw::c_uint,
+        start_offset: ::std::os::raw::c_uint,
+        feature_count: *mut ::std::os::raw::c_uint,
+        feature_indexes: *mut ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_language_get_feature_tags(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        language_index: ::std::os::raw::c_uint,
+        start_offset: ::std::os::raw::c_uint,
+        feature_count: *mut ::std::os::raw::c_uint,
+        feature_tags: *mut hb_tag_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_language_find_feature(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        script_index: ::std::os::raw::c_uint,
+        language_index: ::std::os::raw::c_uint,
+        feature_tag: hb_tag_t,
+        feature_index: *mut ::std::os::raw::c_uint,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_feature_get_lookups(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        feature_index: ::std::os::raw::c_uint,
+        start_offset: ::std::os::raw::c_uint,
+        lookup_count: *mut ::std::os::raw::c_uint,
+        lookup_indexes: *mut ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_table_get_lookup_count(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_collect_lookups(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        scripts: *const hb_tag_t,
+        languages: *const hb_tag_t,
+        features: *const hb_tag_t,
+        lookup_indexes: *mut hb_set_t,
+    );
+}
+extern "C" {
+    pub fn hb_ot_layout_lookup_collect_glyphs(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        lookup_index: ::std::os::raw::c_uint,
+        glyphs_before: *mut hb_set_t,
+        glyphs_input: *mut hb_set_t,
+        glyphs_after: *mut hb_set_t,
+        glyphs_output: *mut hb_set_t,
+    );
+}
+extern "C" {
+    pub fn hb_ot_layout_table_find_feature_variations(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        coords: *const ::std::os::raw::c_int,
+        num_coords: ::std::os::raw::c_uint,
+        variations_index: *mut ::std::os::raw::c_uint,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_feature_with_variations_get_lookups(
+        face: *mut hb_face_t,
+        table_tag: hb_tag_t,
+        feature_index: ::std::os::raw::c_uint,
+        variations_index: ::std::os::raw::c_uint,
+        start_offset: ::std::os::raw::c_uint,
+        lookup_count: *mut ::std::os::raw::c_uint,
+        lookup_indexes: *mut ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_layout_has_substitution(face: *mut hb_face_t) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_lookup_would_substitute(
+        face: *mut hb_face_t,
+        lookup_index: ::std::os::raw::c_uint,
+        glyphs: *const hb_codepoint_t,
+        glyphs_length: ::std::os::raw::c_uint,
+        zero_context: hb_bool_t,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_lookup_substitute_closure(
+        face: *mut hb_face_t,
+        lookup_index: ::std::os::raw::c_uint,
+        glyphs: *mut hb_set_t,
+    );
+}
+extern "C" {
+    pub fn hb_ot_layout_has_positioning(face: *mut hb_face_t) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_layout_get_size_params(
+        face: *mut hb_face_t,
+        design_size: *mut ::std::os::raw::c_uint,
+        subfamily_id: *mut ::std::os::raw::c_uint,
+        subfamily_name_id: *mut ::std::os::raw::c_uint,
+        range_start: *mut ::std::os::raw::c_uint,
+        range_end: *mut ::std::os::raw::c_uint,
+    ) -> hb_bool_t;
+}
+pub const HB_OT_MATH_CONSTANT_SCRIPT_PERCENT_SCALE_DOWN: hb_ot_math_constant_t = 0;
+pub const HB_OT_MATH_CONSTANT_SCRIPT_SCRIPT_PERCENT_SCALE_DOWN: hb_ot_math_constant_t = 1;
+pub const HB_OT_MATH_CONSTANT_DELIMITED_SUB_FORMULA_MIN_HEIGHT: hb_ot_math_constant_t = 2;
+pub const HB_OT_MATH_CONSTANT_DISPLAY_OPERATOR_MIN_HEIGHT: hb_ot_math_constant_t = 3;
+pub const HB_OT_MATH_CONSTANT_MATH_LEADING: hb_ot_math_constant_t = 4;
+pub const HB_OT_MATH_CONSTANT_AXIS_HEIGHT: hb_ot_math_constant_t = 5;
+pub const HB_OT_MATH_CONSTANT_ACCENT_BASE_HEIGHT: hb_ot_math_constant_t = 6;
+pub const HB_OT_MATH_CONSTANT_FLATTENED_ACCENT_BASE_HEIGHT: hb_ot_math_constant_t = 7;
+pub const HB_OT_MATH_CONSTANT_SUBSCRIPT_SHIFT_DOWN: hb_ot_math_constant_t = 8;
+pub const HB_OT_MATH_CONSTANT_SUBSCRIPT_TOP_MAX: hb_ot_math_constant_t = 9;
+pub const HB_OT_MATH_CONSTANT_SUBSCRIPT_BASELINE_DROP_MIN: hb_ot_math_constant_t = 10;
+pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP: hb_ot_math_constant_t = 11;
+pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_SHIFT_UP_CRAMPED: hb_ot_math_constant_t = 12;
+pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MIN: hb_ot_math_constant_t = 13;
+pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_BASELINE_DROP_MAX: hb_ot_math_constant_t = 14;
+pub const HB_OT_MATH_CONSTANT_SUB_SUPERSCRIPT_GAP_MIN: hb_ot_math_constant_t = 15;
+pub const HB_OT_MATH_CONSTANT_SUPERSCRIPT_BOTTOM_MAX_WITH_SUBSCRIPT: hb_ot_math_constant_t = 16;
+pub const HB_OT_MATH_CONSTANT_SPACE_AFTER_SCRIPT: hb_ot_math_constant_t = 17;
+pub const HB_OT_MATH_CONSTANT_UPPER_LIMIT_GAP_MIN: hb_ot_math_constant_t = 18;
+pub const HB_OT_MATH_CONSTANT_UPPER_LIMIT_BASELINE_RISE_MIN: hb_ot_math_constant_t = 19;
+pub const HB_OT_MATH_CONSTANT_LOWER_LIMIT_GAP_MIN: hb_ot_math_constant_t = 20;
+pub const HB_OT_MATH_CONSTANT_LOWER_LIMIT_BASELINE_DROP_MIN: hb_ot_math_constant_t = 21;
+pub const HB_OT_MATH_CONSTANT_STACK_TOP_SHIFT_UP: hb_ot_math_constant_t = 22;
+pub const HB_OT_MATH_CONSTANT_STACK_TOP_DISPLAY_STYLE_SHIFT_UP: hb_ot_math_constant_t = 23;
+pub const HB_OT_MATH_CONSTANT_STACK_BOTTOM_SHIFT_DOWN: hb_ot_math_constant_t = 24;
+pub const HB_OT_MATH_CONSTANT_STACK_BOTTOM_DISPLAY_STYLE_SHIFT_DOWN: hb_ot_math_constant_t = 25;
+pub const HB_OT_MATH_CONSTANT_STACK_GAP_MIN: hb_ot_math_constant_t = 26;
+pub const HB_OT_MATH_CONSTANT_STACK_DISPLAY_STYLE_GAP_MIN: hb_ot_math_constant_t = 27;
+pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_TOP_SHIFT_UP: hb_ot_math_constant_t = 28;
+pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_BOTTOM_SHIFT_DOWN: hb_ot_math_constant_t = 29;
+pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_ABOVE_MIN: hb_ot_math_constant_t = 30;
+pub const HB_OT_MATH_CONSTANT_STRETCH_STACK_GAP_BELOW_MIN: hb_ot_math_constant_t = 31;
+pub const HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_SHIFT_UP: hb_ot_math_constant_t = 32;
+pub const HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_DISPLAY_STYLE_SHIFT_UP: hb_ot_math_constant_t = 33;
+pub const HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_SHIFT_DOWN: hb_ot_math_constant_t = 34;
+pub const HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_DISPLAY_STYLE_SHIFT_DOWN: hb_ot_math_constant_t =
+    35;
+pub const HB_OT_MATH_CONSTANT_FRACTION_NUMERATOR_GAP_MIN: hb_ot_math_constant_t = 36;
+pub const HB_OT_MATH_CONSTANT_FRACTION_NUM_DISPLAY_STYLE_GAP_MIN: hb_ot_math_constant_t = 37;
+pub const HB_OT_MATH_CONSTANT_FRACTION_RULE_THICKNESS: hb_ot_math_constant_t = 38;
+pub const HB_OT_MATH_CONSTANT_FRACTION_DENOMINATOR_GAP_MIN: hb_ot_math_constant_t = 39;
+pub const HB_OT_MATH_CONSTANT_FRACTION_DENOM_DISPLAY_STYLE_GAP_MIN: hb_ot_math_constant_t = 40;
+pub const HB_OT_MATH_CONSTANT_SKEWED_FRACTION_HORIZONTAL_GAP: hb_ot_math_constant_t = 41;
+pub const HB_OT_MATH_CONSTANT_SKEWED_FRACTION_VERTICAL_GAP: hb_ot_math_constant_t = 42;
+pub const HB_OT_MATH_CONSTANT_OVERBAR_VERTICAL_GAP: hb_ot_math_constant_t = 43;
+pub const HB_OT_MATH_CONSTANT_OVERBAR_RULE_THICKNESS: hb_ot_math_constant_t = 44;
+pub const HB_OT_MATH_CONSTANT_OVERBAR_EXTRA_ASCENDER: hb_ot_math_constant_t = 45;
+pub const HB_OT_MATH_CONSTANT_UNDERBAR_VERTICAL_GAP: hb_ot_math_constant_t = 46;
+pub const HB_OT_MATH_CONSTANT_UNDERBAR_RULE_THICKNESS: hb_ot_math_constant_t = 47;
+pub const HB_OT_MATH_CONSTANT_UNDERBAR_EXTRA_DESCENDER: hb_ot_math_constant_t = 48;
+pub const HB_OT_MATH_CONSTANT_RADICAL_VERTICAL_GAP: hb_ot_math_constant_t = 49;
+pub const HB_OT_MATH_CONSTANT_RADICAL_DISPLAY_STYLE_VERTICAL_GAP: hb_ot_math_constant_t = 50;
+pub const HB_OT_MATH_CONSTANT_RADICAL_RULE_THICKNESS: hb_ot_math_constant_t = 51;
+pub const HB_OT_MATH_CONSTANT_RADICAL_EXTRA_ASCENDER: hb_ot_math_constant_t = 52;
+pub const HB_OT_MATH_CONSTANT_RADICAL_KERN_BEFORE_DEGREE: hb_ot_math_constant_t = 53;
+pub const HB_OT_MATH_CONSTANT_RADICAL_KERN_AFTER_DEGREE: hb_ot_math_constant_t = 54;
+pub const HB_OT_MATH_CONSTANT_RADICAL_DEGREE_BOTTOM_RAISE_PERCENT: hb_ot_math_constant_t = 55;
+pub type hb_ot_math_constant_t = ::std::os::raw::c_uint;
+pub const HB_OT_MATH_KERN_TOP_RIGHT: hb_ot_math_kern_t = 0;
+pub const HB_OT_MATH_KERN_TOP_LEFT: hb_ot_math_kern_t = 1;
+pub const HB_OT_MATH_KERN_BOTTOM_RIGHT: hb_ot_math_kern_t = 2;
+pub const HB_OT_MATH_KERN_BOTTOM_LEFT: hb_ot_math_kern_t = 3;
+pub type hb_ot_math_kern_t = ::std::os::raw::c_uint;
+/// hb_ot_math_glyph_variant_t:
+///
+/// Since: 1.3.3
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hb_ot_math_glyph_variant_t {
+    pub glyph: hb_codepoint_t,
+    pub advance: hb_position_t,
+}
+#[test]
+fn bindgen_test_layout_hb_ot_math_glyph_variant_t() {
+    assert_eq!(
+        ::std::mem::size_of::<hb_ot_math_glyph_variant_t>(),
+        8usize,
+        concat!("Size of: ", stringify!(hb_ot_math_glyph_variant_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hb_ot_math_glyph_variant_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(hb_ot_math_glyph_variant_t))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hb_ot_math_glyph_variant_t>())).glyph as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_variant_t),
+            "::",
+            stringify!(glyph)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hb_ot_math_glyph_variant_t>())).advance as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_variant_t),
+            "::",
+            stringify!(advance)
+        )
+    );
+}
+pub const HB_MATH_GLYPH_PART_FLAG_EXTENDER: hb_ot_math_glyph_part_flags_t = 1;
+pub type hb_ot_math_glyph_part_flags_t = ::std::os::raw::c_uint;
+/// hb_ot_math_glyph_part_t:
+///
+/// Since: 1.3.3
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hb_ot_math_glyph_part_t {
+    pub glyph: hb_codepoint_t,
+    pub start_connector_length: hb_position_t,
+    pub end_connector_length: hb_position_t,
+    pub full_advance: hb_position_t,
+    pub flags: hb_ot_math_glyph_part_flags_t,
+}
+#[test]
+fn bindgen_test_layout_hb_ot_math_glyph_part_t() {
+    assert_eq!(
+        ::std::mem::size_of::<hb_ot_math_glyph_part_t>(),
+        20usize,
+        concat!("Size of: ", stringify!(hb_ot_math_glyph_part_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hb_ot_math_glyph_part_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(hb_ot_math_glyph_part_t))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_math_glyph_part_t>())).glyph as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_part_t),
+            "::",
+            stringify!(glyph)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hb_ot_math_glyph_part_t>())).start_connector_length as *const _
+                as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_part_t),
+            "::",
+            stringify!(start_connector_length)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hb_ot_math_glyph_part_t>())).end_connector_length as *const _
+                as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_part_t),
+            "::",
+            stringify!(end_connector_length)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<hb_ot_math_glyph_part_t>())).full_advance as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_part_t),
+            "::",
+            stringify!(full_advance)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_math_glyph_part_t>())).flags as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_math_glyph_part_t),
+            "::",
+            stringify!(flags)
+        )
+    );
+}
+extern "C" {
+    pub fn hb_ot_math_has_data(face: *mut hb_face_t) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_math_get_constant(
+        font: *mut hb_font_t,
+        constant: hb_ot_math_constant_t,
+    ) -> hb_position_t;
+}
+extern "C" {
+    pub fn hb_ot_math_get_glyph_italics_correction(
+        font: *mut hb_font_t,
+        glyph: hb_codepoint_t,
+    ) -> hb_position_t;
+}
+extern "C" {
+    pub fn hb_ot_math_get_glyph_top_accent_attachment(
+        font: *mut hb_font_t,
+        glyph: hb_codepoint_t,
+    ) -> hb_position_t;
+}
+extern "C" {
+    pub fn hb_ot_math_is_glyph_extended_shape(
+        face: *mut hb_face_t,
+        glyph: hb_codepoint_t,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_math_get_glyph_kerning(
+        font: *mut hb_font_t,
+        glyph: hb_codepoint_t,
+        kern: hb_ot_math_kern_t,
+        correction_height: hb_position_t,
+    ) -> hb_position_t;
+}
+extern "C" {
+    pub fn hb_ot_math_get_glyph_variants(
+        font: *mut hb_font_t,
+        glyph: hb_codepoint_t,
+        direction: hb_direction_t,
+        start_offset: ::std::os::raw::c_uint,
+        variants_count: *mut ::std::os::raw::c_uint,
+        variants: *mut hb_ot_math_glyph_variant_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_math_get_min_connector_overlap(
+        font: *mut hb_font_t,
+        direction: hb_direction_t,
+    ) -> hb_position_t;
+}
+extern "C" {
+    pub fn hb_ot_math_get_glyph_assembly(
+        font: *mut hb_font_t,
+        glyph: hb_codepoint_t,
+        direction: hb_direction_t,
+        start_offset: ::std::os::raw::c_uint,
+        parts_count: *mut ::std::os::raw::c_uint,
+        parts: *mut hb_ot_math_glyph_part_t,
+        italics_correction: *mut hb_position_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_shape_glyphs_closure(
+        font: *mut hb_font_t,
+        buffer: *mut hb_buffer_t,
+        features: *const hb_feature_t,
+        num_features: ::std::os::raw::c_uint,
+        glyphs: *mut hb_set_t,
+    );
+}
+extern "C" {
+    pub fn hb_ot_shape_plan_collect_lookups(
+        shape_plan: *mut hb_shape_plan_t,
+        table_tag: hb_tag_t,
+        lookup_indexes: *mut hb_set_t,
+    );
+}
+/// hb_ot_var_axis_t:
+///
+/// Since: 1.4.2
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct hb_ot_var_axis_t {
+    pub tag: hb_tag_t,
+    pub name_id: ::std::os::raw::c_uint,
+    pub min_value: f32,
+    pub default_value: f32,
+    pub max_value: f32,
+}
+#[test]
+fn bindgen_test_layout_hb_ot_var_axis_t() {
+    assert_eq!(
+        ::std::mem::size_of::<hb_ot_var_axis_t>(),
+        20usize,
+        concat!("Size of: ", stringify!(hb_ot_var_axis_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<hb_ot_var_axis_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(hb_ot_var_axis_t))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_var_axis_t>())).tag as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_var_axis_t),
+            "::",
+            stringify!(tag)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_var_axis_t>())).name_id as *const _ as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_var_axis_t),
+            "::",
+            stringify!(name_id)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_var_axis_t>())).min_value as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_var_axis_t),
+            "::",
+            stringify!(min_value)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_var_axis_t>())).default_value as *const _ as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_var_axis_t),
+            "::",
+            stringify!(default_value)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<hb_ot_var_axis_t>())).max_value as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(hb_ot_var_axis_t),
+            "::",
+            stringify!(max_value)
+        )
+    );
+}
+extern "C" {
+    pub fn hb_ot_var_has_data(face: *mut hb_face_t) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_var_get_axis_count(face: *mut hb_face_t) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_var_get_axes(
+        face: *mut hb_face_t,
+        start_offset: ::std::os::raw::c_uint,
+        axes_count: *mut ::std::os::raw::c_uint,
+        axes_array: *mut hb_ot_var_axis_t,
+    ) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn hb_ot_var_find_axis(
+        face: *mut hb_face_t,
+        axis_tag: hb_tag_t,
+        axis_index: *mut ::std::os::raw::c_uint,
+        axis_info: *mut hb_ot_var_axis_t,
+    ) -> hb_bool_t;
+}
+extern "C" {
+    pub fn hb_ot_var_normalize_variations(
+        face: *mut hb_face_t,
+        variations: *const hb_variation_t,
+        variations_length: ::std::os::raw::c_uint,
+        coords: *mut ::std::os::raw::c_int,
+        coords_length: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    pub fn hb_ot_var_normalize_coords(
+        face: *mut hb_face_t,
+        coords_length: ::std::os::raw::c_uint,
+        design_coords: *const f32,
+        normalized_coords: *mut ::std::os::raw::c_int,
+    );
 }


### PR DESCRIPTION
`hb-ot.h` isn't included by `hb.h`, so bindings for the OpenType APIs weren't being generated. This corrects that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/102)
<!-- Reviewable:end -->
