### PR TITLE
WIP: Basic support for text shaping

### DIFF
--- a/harfbuzz/src/feature.rs
+++ b/harfbuzz/src/feature.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(missing_docs)]
+
+use std;
+use sys;
+
+pub struct Features {
+    features: Vec<sys::hb_feature_t>,
+}
+
+impl Features {
+    pub fn add_from_string(&mut self, s: &str) -> Result<(), ()> {
+        unsafe {
+            let mut feature = std::mem::zeroed();
+            if sys::hb_feature_from_string(
+                s.as_ptr() as *const std::os::raw::c_char,
+                s.len() as std::os::raw::c_int,
+                &mut feature
+            ) == 0 {
+                return Err(())
+            }
+            self.features.push(feature);
+        }
+        Ok(())
+    }
+
+    pub fn raw_features(&self) -> &[sys::hb_feature_t] {
+        &self.features
+    }
+}

--- a/harfbuzz/src/font.rs
+++ b/harfbuzz/src/font.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(missing_docs)]
+
+use std;
+use sys;
+
+pub struct Font {
+    raw: *mut sys::hb_font_t,
+}
+
+impl Font {
+    /// Construct a `Font` from a raw pointer. Takes ownership of the font.
+    pub unsafe fn from_raw(raw: *mut sys::hb_font_t) -> Self {
+        Font { raw }
+    }
+
+    /// Borrows a raw pointer to the font.
+    pub fn as_raw(&self) -> *mut sys::hb_font_t {
+        self.raw
+    }
+
+    /// Gives up ownership and returns a raw pointer to the font.
+    pub fn into_raw(self) -> *mut sys::hb_font_t {
+        let raw = self.raw;
+        std::mem::forget(self);
+        raw
+    }
+}
+
+impl Drop for Font {
+    fn drop(&mut self) {
+        unsafe { sys::hb_font_destroy(self.raw) }
+    }
+}

--- a/harfbuzz/src/glyph.rs
+++ b/harfbuzz/src/glyph.rs
@@ -1,0 +1,81 @@
+// Copyright 2018 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(missing_docs)]
+
+use std;
+use sys;
+
+pub struct Glyphs<'a> {
+    infos: *const sys::hb_glyph_info_t,
+    positions: *const sys::hb_glyph_position_t,
+    len: usize,
+    phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Glyphs<'a> {
+    pub unsafe fn from_raw(
+        infos: *const sys::hb_glyph_info_t,
+        positions: *const sys::hb_glyph_position_t,
+        len: std::os::raw::c_uint,
+    ) -> Self {
+        Glyphs {
+            infos,
+            positions,
+            len: len as usize,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, idx: usize) -> Glyph<'a> {
+        assert!(idx < self.len, "Index {} is out of range", idx);
+        unsafe { self.get_unchecked(idx) }
+    }
+
+    #[inline]
+    pub unsafe fn get_unchecked(&self, idx: usize) -> Glyph<'a> {
+        Glyph {
+            info: self.infos.add(idx),
+            position: self.positions.add(idx),
+            phantom: self.phantom,
+        }
+    }
+}
+
+pub struct Glyph<'a> {
+    info: *const sys::hb_glyph_info_t,
+    position: *const sys::hb_glyph_position_t,
+    phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Glyph<'a> {
+    /// Either a Unicode code point (before shaping) or a glyph ID (after shaping)
+    pub fn id(&self) -> u32 {
+        self.raw_info().codepoint
+    }
+
+    /// For glyphs that represent Unicode code points (before shaping), returns the Unicode
+    /// code point as a `char`.
+    ///
+    /// Not valid (and may panic) if called after shaping.
+    pub fn to_char(&self) -> char {
+        std::char::from_u32(self.id()).expect("not a Unicode code point")
+    }
+
+    /// Access to the raw `hb_glyph_info_t`
+    pub fn raw_info(&self) -> &sys::hb_glyph_info_t {
+        unsafe { &*self.info }
+    }
+
+    /// Access to the raw `hb_glyph_position_t`
+    pub fn raw_position(&self) -> &sys::hb_glyph_position_t {
+        unsafe { &*self.position }
+    }
+}

--- a/harfbuzz/src/lib.rs
+++ b/harfbuzz/src/lib.rs
@@ -29,3 +29,6 @@ pub use self::blob::Blob;
 
 mod glyph;
 pub use self::glyph::{Glyph, Glyphs};
+
+mod font;
+pub use self::font::Font;

--- a/harfbuzz/src/lib.rs
+++ b/harfbuzz/src/lib.rs
@@ -32,3 +32,6 @@ pub use self::glyph::{Glyph, Glyphs};
 
 mod font;
 pub use self::font::Font;
+
+mod feature;
+pub use self::feature::Features;

--- a/harfbuzz/src/lib.rs
+++ b/harfbuzz/src/lib.rs
@@ -26,3 +26,6 @@ pub use self::language::Language;
 
 mod blob;
 pub use self::blob::Blob;
+
+mod glyph;
+pub use self::glyph::{Glyph, Glyphs};


### PR DESCRIPTION
This adds very minimal support for using `hb_shape` through the safe Rust API.  It's not very complete, and I welcome any feedback on the design.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/112)
<!-- Reviewable:end -->
