### PR TITLE
Remove Clone impls for Buffer and Blob

### DIFF
--- a/harfbuzz/src/blob.rs
+++ b/harfbuzz/src/blob.rs
@@ -93,15 +93,6 @@ impl ops::DerefMut for Blob {
     }
 }
 
-impl Clone for Blob {
-    /// Increment the reference count and return a new reference to the same blob.
-    fn clone(&self) -> Self {
-        unsafe {
-            Blob::from_raw(sys::hb_blob_reference(self.raw))
-        }
-    }
-}
-
 impl Drop for Blob {
     /// Decrement the reference count, and destroy the blob if the reference count is zero.
     fn drop(&mut self) {

--- a/harfbuzz/src/buffer.rs
+++ b/harfbuzz/src/buffer.rs
@@ -319,15 +319,6 @@ impl Default for Buffer {
     }
 }
 
-impl Clone for Buffer {
-    /// Increment the reference count and return a new reference to the same buffer.
-    fn clone(&self) -> Self {
-        Buffer {
-            raw: unsafe { sys::hb_buffer_reference(self.raw) },
-        }
-    }
-}
-
 impl Drop for Buffer {
     fn drop(&mut self) {
         unsafe { sys::hb_buffer_destroy(self.raw) }


### PR DESCRIPTION
Reverts #111.

I realized that allowing these types to be cloned makes it impossible to provide safe borrowed access to their contents, because one handle could mutate or clear the contents while they are borrowed through another handle.

Rust code that needs multiple pointers to a single buffer or blob should use Rc/Arc or `&T` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/113)
<!-- Reviewable:end -->
