### PR TITLE
Use a supported architecture for armv7 builds using the llvm toolchain.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.2.0"
+version = "0.2.1"
 
 authors = ["The Servo Project Developers"]
 license = "MIT"

--- a/harfbuzz-sys/makefile.cargo
+++ b/harfbuzz-sys/makefile.cargo
@@ -4,7 +4,7 @@ ifeq (armv7-linux-androideabi,$(TARGET))
 	# Reset TARGET variable because armv7 target name used by Rust is not 
 	# the same as the target name needed for the CXX toolchain.
 	TARGET = arm-linux-androideabi
-	FLAGS += -march=armv7-a -mfpu=neon
+	FLAGS += -march=armv7a -mfpu=neon
 endif
 
 ifneq ($(HOST),$(TARGET))


### PR DESCRIPTION
Clang doesn't like the hyphen in the arch name and refuses to build if it's present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/115)
<!-- Reviewable:end -->
