### PR TITLE
fixup compilation of libharfbuzz on macos

### DIFF
--- a/harfbuzz-sys/makefile.cargo
+++ b/harfbuzz-sys/makefile.cargo
@@ -33,11 +33,8 @@ CONFIGURE_FLAGS = \
 	--disable-shared \
 	--without-icu \
 	--without-freetype \
-	--without-glib
-
-ifeq ("apple-darwin",$(findstring "apple-darwin",$(TARGET)))
-	CONFIGURE_FLAGS += --with-coretext
-endif
+	--without-glib \
+	--with-coretext=auto
 
 all:
 	touch -r harfbuzz/configure $(AUTOMAKE_FILES)


### PR DESCRIPTION
The library is missing coretext features on macos; this manifests
in the travis build for wezterm here:

https://travis-ci.org/wez/wezterm/jobs/497309625

```
            "_hb_coretext_font_create", referenced from:
                wezterm::font::hbwrap::Font::new_coretext::hd071aafeac2e8295 in wezterm-0dd706f6ee97bf14.10pwsdaw58utpw8o.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Inspecting the output of the build shows that configure is being invoked this way:

```
cd /Users/wez/src/wezterm/target/debug/build/harfbuzz-sys-0ec3b8d6c31c3064/out && /Users/wez/.cargo/registry/src/github.com-1ecc6299db9ec823/harfbu
zz-sys-0.3.0/harfbuzz/configure --prefix=/Users/wez/src/wezterm/target/debug/build/harfbuzz-sys-0ec3b8d6c31c3064/out --host=x86_64-apple-darwin --e
nable-static --disable-shared --without-icu --without-freetype --without-glib \
                CFLAGS="-fPIC -g" CXXFLAGS="-fPIC -g" CPPFLAGS=""
```

It appears that the logic in `makefile.cargo` isn't effective at detecting macos
in either the travis mac environment or on my local macbook (after I uninstalled
my locally installed hombrew harfbuzz).

This commit changes the invocation to unconditionally ask configure to probe for
coretext and enable it if found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/128)
<!-- Reviewable:end -->
