### PR TITLE
Add "build-native-harfbuzz" and "build-native-freetype" features

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -15,8 +15,13 @@ links = "harfbuzz"
 build = "build.rs"
 
 [build-dependencies]
-pkg-config = "0.3"
-cmake = "0.1"
+pkg-config = { version = "0.3", optional = true }
+cmake = { version = "0.1", optional = true }
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
-freetype = "0.4"
+freetype = { version = "0.4", default-features = false }
+
+[features]
+default = ["build-native-harfbuzz", "build-native-freetype"]
+build-native-harfbuzz = ["cmake", "pkg-config"]
+build-native-freetype = ["freetype/servo-freetype-sys"]

--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -1,11 +1,14 @@
+#[cfg(feature = "build-native-harfbuzz")]
 extern crate cmake;
+#[cfg(feature = "build-native-harfbuzz")]
 extern crate pkg_config;
 
-use std::env;
-use std::process::Command;
-use std::path::PathBuf;
-
+#[cfg(feature = "build-native-harfbuzz")]
 fn main() {
+    use std::env;
+    use std::process::Command;
+    use std::path::PathBuf;
+
     println!("cargo:rerun-if-env-changed=HARFBUZZ_SYS_NO_PKG_CONFIG");
     if env::var_os("HARFBUZZ_SYS_NO_PKG_CONFIG").is_none() {
         if pkg_config::find_library("harfbuzz").is_ok() {
@@ -48,3 +51,6 @@ fn main() {
         env::current_dir().unwrap().join("harfbuzz/src").display()
     );
 }
+
+#[cfg(not(feature = "build-native-harfbuzz"))]
+fn main() {}

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -13,3 +13,9 @@ keywords = ["opentype", "font", "text", "layout", "unicode"]
 [dependencies.harfbuzz-sys]
 path = "../harfbuzz-sys"
 version = "0.3.0"
+default-features = false
+
+[features]
+default = ["build-native-harfbuzz", "build-native-freetype"]
+build-native-harfbuzz = ["harfbuzz-sys/build-native-harfbuzz"]
+build-native-freetype = ["harfbuzz-sys/build-native-freetype"]


### PR DESCRIPTION
- Declare default features "build-native-harfbuzz" and "build-native-freetype".
- Make the pkg-config and cmake build-dependencies optional.
- Make build.rs a no-op if "build-native-harfbuzz" is disabled.

These changes allow the library to be used in projects where the native harfbuzz and freetype librares are built separately, and where cmake and pkg-config are not supported.

Depends on servo/rust-freetype#57.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/129)
<!-- Reviewable:end -->
