### PR TITLE
macOS: Add bindings for hb-coretext functions.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -18,6 +18,11 @@ build = "build.rs"
 pkg-config = { version = "0.3", optional = true }
 cmake = { version = "0.1", optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-graphics = "0.17"
+core-text = "13"
+foreign-types = "0.3"
+
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
 freetype = { version = "0.4", default-features = false }
 

--- a/harfbuzz-sys/src/coretext.rs
+++ b/harfbuzz-sys/src/coretext.rs
@@ -1,0 +1,18 @@
+extern crate core_graphics;
+extern crate core_text;
+extern crate foreign_types;
+
+use {hb_face_t, hb_font_t};
+
+use self::core_text::font::CTFontRef;
+use self::foreign_types::ForeignType;
+use self::core_graphics::font::CGFont;
+
+type CGFontRef = *mut <CGFont as ForeignType>::CType;
+
+extern "C" {
+    pub fn hb_coretext_face_create(cg_font: CGFontRef) -> *mut hb_face_t;
+    pub fn hb_coretext_font_create(ct_font: CTFontRef) -> *mut hb_font_t;
+    pub fn hb_coretext_face_get_cg_font(face: *mut hb_face_t) -> CGFontRef;
+    pub fn hb_coretext_font_get_ct_font(font: *mut hb_font_t) -> CTFontRef;
+}

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -4,6 +4,9 @@
 #[cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))]
 extern crate freetype;
 
+#[cfg(target_os = "macos")]
+pub mod coretext;
+
 #[cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))]
 extern "C" {
     pub fn hb_ft_font_create_referenced(face: freetype::freetype::FT_Face) -> *mut hb_font_t;


### PR DESCRIPTION
This adds a macOS-only dependency upon core_graphics, core_text,
and foreign_types, so that we can interop with the CGFontRef
and CTFontRef values from the existing core_graphics and core_text
bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/133)
<!-- Reviewable:end -->
