### PR TITLE
Exclude test data from published crate.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -11,6 +11,10 @@ documentation = "https://docs.rs/harfbuzz-sys/"
 keywords = ["opentype", "font", "text", "layout", "unicode"]
 categories = ["external-ffi-bindings", "internationalization"]
 
+exclude = [
+    "harfbuzz/test/*"
+]
+
 links = "harfbuzz"
 build = "build.rs"
 


### PR DESCRIPTION
The crates.io limit is 10mb, but the latest package is 20mb. The test data is 32mb out of 43mb uncompressed, and the crate builds fine without it. The final package size is 2.2mb.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/136)
<!-- Reviewable:end -->
