### PR TITLE
Add harfbuzz-sys-test using ctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rust:
 script:
  - touch harfbuzz-sys/harfbuzz/{configure.ac,aclocal.m4,configure,Makefile.am,Makefile.in}
  - cargo build --verbose --manifest-path=harfbuzz-sys/Cargo.toml
+ - cd harfbuzz-sys-test
+ - env HARFBUZZ_SYS_NO_PKG_CONFIG=1 cargo run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["harfbuzz", "harfbuzz-sys"]
+members = ["harfbuzz", "harfbuzz-sys", "harfbuzz-sys-test"]

--- a/harfbuzz-sys-test/Cargo.toml
+++ b/harfbuzz-sys-test/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "harfbuzz-sys-test"
+version = "0.1.0"
+authors = ["Sean Leather <sean.leather@gmail.com>"]
+edition = "2018"
+build = "build.rs"
+
+[dependencies]
+harfbuzz-sys = { path = "../harfbuzz-sys" }
+
+[build-dependencies]
+ctest = "0.2"

--- a/harfbuzz-sys-test/build.rs
+++ b/harfbuzz-sys-test/build.rs
@@ -17,10 +17,10 @@ fn main() {
     }
 
     // Include the header files where the C APIs are defined.
-    cfg.header("hb.h")
-        .header("hb-coretext.h")
-        .header("hb-ot.h")
-        .header("hb-aat.h");
+    cfg.header("hb.h").header("hb-ot.h").header("hb-aat.h");
+
+    #[cfg(target_os = "macos")]
+    cfg.header("hb-coretext.h");
 
     // Skip structs that are empty on the Rust side.
     cfg.skip_struct(|s| {

--- a/harfbuzz-sys-test/build.rs
+++ b/harfbuzz-sys-test/build.rs
@@ -37,7 +37,11 @@ fn main() {
     });
 
     // FIXME: I'm not sure why these functions must be skipped.
-    cfg.skip_fn(|s| s == "hb_coretext_face_create" || s == "hb_coretext_face_get_cg_font");
+    cfg.skip_fn(|s| {
+        s == "hb_coretext_face_create"
+            || s == "hb_coretext_face_get_cg_font"
+            || s == "hb_ft_font_create_referenced"
+    });
 
     // Generate the tests, passing the path to the `*-sys` library as well as
     // the module to generate.

--- a/harfbuzz-sys-test/build.rs
+++ b/harfbuzz-sys-test/build.rs
@@ -1,0 +1,45 @@
+extern crate ctest;
+
+use std::env;
+
+fn main() {
+    let mut cfg = ctest::TestGenerator::new();
+
+    // Get the include paths from the environment variable exported by harfbuzz-sys. If the
+    // variables is not found, fail with a meaningful error.
+    match &env::var_os("DEP_HARFBUZZ_INCLUDE") {
+        Some(include_paths) => {
+            for path in env::split_paths(include_paths) {
+                cfg.include(path);
+            }
+        }
+        None => panic!("$DEP_HARFBUZZ_INCLUDE not found."),
+    }
+
+    // Include the header files where the C APIs are defined.
+    cfg.header("hb.h")
+        .header("hb-coretext.h")
+        .header("hb-ot.h")
+        .header("hb-aat.h");
+
+    // Skip structs that are empty on the Rust side.
+    cfg.skip_struct(|s| {
+        s == "hb_language_impl_t"
+            || s == "hb_blob_t"
+            || s == "hb_unicode_funcs_t"
+            || s == "hb_set_t"
+            || s == "hb_face_t"
+            || s == "hb_font_t"
+            || s == "hb_font_funcs_t"
+            || s == "hb_buffer_t"
+            || s == "hb_map_t"
+            || s == "hb_shape_plan_t"
+    });
+
+    // FIXME: I'm not sure why these functions must be skipped.
+    cfg.skip_fn(|s| s == "hb_coretext_face_create" || s == "hb_coretext_face_get_cg_font");
+
+    // Generate the tests, passing the path to the `*-sys` library as well as
+    // the module to generate.
+    cfg.generate("../harfbuzz-sys/src/lib.rs", "all.rs");
+}

--- a/harfbuzz-sys-test/src/main.rs
+++ b/harfbuzz-sys-test/src/main.rs
@@ -1,0 +1,8 @@
+#![allow(bad_style, improper_ctypes)]
+
+extern crate harfbuzz_sys;
+
+use harfbuzz_sys::coretext::*;
+use harfbuzz_sys::*;
+
+include!(concat!(env!("OUT_DIR"), "/all.rs"));

--- a/harfbuzz-sys-test/src/main.rs
+++ b/harfbuzz-sys-test/src/main.rs
@@ -2,6 +2,7 @@
 
 extern crate harfbuzz_sys;
 
+#[cfg(target_os = "macos")]
 use harfbuzz_sys::coretext::*;
 use harfbuzz_sys::*;
 

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -448,7 +448,7 @@ extern "C" {
 #[derive(Debug, Copy, Clone)]
 pub struct hb_variation_t {
     pub tag: hb_tag_t,
-    pub value: f32,
+    pub value: ::std::os::raw::c_float,
 }
 #[test]
 fn bindgen_test_layout_hb_variation_t() {
@@ -2049,10 +2049,10 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn hb_font_set_ptem(font: *mut hb_font_t, ptem: f32);
+    pub fn hb_font_set_ptem(font: *mut hb_font_t, ptem: ::std::os::raw::c_float);
 }
 extern "C" {
-    pub fn hb_font_get_ptem(font: *mut hb_font_t) -> f32;
+    pub fn hb_font_get_ptem(font: *mut hb_font_t) -> ::std::os::raw::c_float;
 }
 extern "C" {
     pub fn hb_font_set_variations(
@@ -2064,7 +2064,7 @@ extern "C" {
 extern "C" {
     pub fn hb_font_set_var_coords_design(
         font: *mut hb_font_t,
-        coords: *const f32,
+        coords: *const ::std::os::raw::c_float,
         coords_length: ::std::os::raw::c_uint,
     );
 }
@@ -2937,32 +2937,32 @@ extern "C" {
         micro: ::std::os::raw::c_uint,
     ) -> hb_bool_t;
 }
-pub const HB_OT_NAME_ID_COPYRIGHT: _bindgen_ty_1 = 0;
-pub const HB_OT_NAME_ID_FONT_FAMILY: _bindgen_ty_1 = 1;
-pub const HB_OT_NAME_ID_FONT_SUBFAMILY: _bindgen_ty_1 = 2;
-pub const HB_OT_NAME_ID_UNIQUE_ID: _bindgen_ty_1 = 3;
-pub const HB_OT_NAME_ID_FULL_NAME: _bindgen_ty_1 = 4;
-pub const HB_OT_NAME_ID_VERSION_STRING: _bindgen_ty_1 = 5;
-pub const HB_OT_NAME_ID_POSTSCRIPT_NAME: _bindgen_ty_1 = 6;
-pub const HB_OT_NAME_ID_TRADEMARK: _bindgen_ty_1 = 7;
-pub const HB_OT_NAME_ID_MANUFACTURER: _bindgen_ty_1 = 8;
-pub const HB_OT_NAME_ID_DESIGNER: _bindgen_ty_1 = 9;
-pub const HB_OT_NAME_ID_DESCRIPTION: _bindgen_ty_1 = 10;
-pub const HB_OT_NAME_ID_VENDOR_URL: _bindgen_ty_1 = 11;
-pub const HB_OT_NAME_ID_DESIGNER_URL: _bindgen_ty_1 = 12;
-pub const HB_OT_NAME_ID_LICENSE: _bindgen_ty_1 = 13;
-pub const HB_OT_NAME_ID_LICENSE_URL: _bindgen_ty_1 = 14;
-pub const HB_OT_NAME_ID_TYPOGRAPHIC_FAMILY: _bindgen_ty_1 = 16;
-pub const HB_OT_NAME_ID_TYPOGRAPHIC_SUBFAMILY: _bindgen_ty_1 = 17;
-pub const HB_OT_NAME_ID_MAC_FULL_NAME: _bindgen_ty_1 = 18;
-pub const HB_OT_NAME_ID_SAMPLE_TEXT: _bindgen_ty_1 = 19;
-pub const HB_OT_NAME_ID_CID_FINDFONT_NAME: _bindgen_ty_1 = 20;
-pub const HB_OT_NAME_ID_WWS_FAMILY: _bindgen_ty_1 = 21;
-pub const HB_OT_NAME_ID_WWS_SUBFAMILY: _bindgen_ty_1 = 22;
-pub const HB_OT_NAME_ID_LIGHT_BACKGROUND: _bindgen_ty_1 = 23;
-pub const HB_OT_NAME_ID_DARK_BACKGROUND: _bindgen_ty_1 = 24;
-pub const HB_OT_NAME_ID_VARIATIONS_PS_PREFIX: _bindgen_ty_1 = 25;
-pub const HB_OT_NAME_ID_INVALID: _bindgen_ty_1 = 65535;
+pub const HB_OT_NAME_ID_COPYRIGHT: hb_ot_name_id_t = 0;
+pub const HB_OT_NAME_ID_FONT_FAMILY: hb_ot_name_id_t = 1;
+pub const HB_OT_NAME_ID_FONT_SUBFAMILY: hb_ot_name_id_t = 2;
+pub const HB_OT_NAME_ID_UNIQUE_ID: hb_ot_name_id_t = 3;
+pub const HB_OT_NAME_ID_FULL_NAME: hb_ot_name_id_t = 4;
+pub const HB_OT_NAME_ID_VERSION_STRING: hb_ot_name_id_t = 5;
+pub const HB_OT_NAME_ID_POSTSCRIPT_NAME: hb_ot_name_id_t = 6;
+pub const HB_OT_NAME_ID_TRADEMARK: hb_ot_name_id_t = 7;
+pub const HB_OT_NAME_ID_MANUFACTURER: hb_ot_name_id_t = 8;
+pub const HB_OT_NAME_ID_DESIGNER: hb_ot_name_id_t = 9;
+pub const HB_OT_NAME_ID_DESCRIPTION: hb_ot_name_id_t = 10;
+pub const HB_OT_NAME_ID_VENDOR_URL: hb_ot_name_id_t = 11;
+pub const HB_OT_NAME_ID_DESIGNER_URL: hb_ot_name_id_t = 12;
+pub const HB_OT_NAME_ID_LICENSE: hb_ot_name_id_t = 13;
+pub const HB_OT_NAME_ID_LICENSE_URL: hb_ot_name_id_t = 14;
+pub const HB_OT_NAME_ID_TYPOGRAPHIC_FAMILY: hb_ot_name_id_t = 16;
+pub const HB_OT_NAME_ID_TYPOGRAPHIC_SUBFAMILY: hb_ot_name_id_t = 17;
+pub const HB_OT_NAME_ID_MAC_FULL_NAME: hb_ot_name_id_t = 18;
+pub const HB_OT_NAME_ID_SAMPLE_TEXT: hb_ot_name_id_t = 19;
+pub const HB_OT_NAME_ID_CID_FINDFONT_NAME: hb_ot_name_id_t = 20;
+pub const HB_OT_NAME_ID_WWS_FAMILY: hb_ot_name_id_t = 21;
+pub const HB_OT_NAME_ID_WWS_SUBFAMILY: hb_ot_name_id_t = 22;
+pub const HB_OT_NAME_ID_LIGHT_BACKGROUND: hb_ot_name_id_t = 23;
+pub const HB_OT_NAME_ID_DARK_BACKGROUND: hb_ot_name_id_t = 24;
+pub const HB_OT_NAME_ID_VARIATIONS_PS_PREFIX: hb_ot_name_id_t = 25;
+pub const HB_OT_NAME_ID_INVALID: hb_ot_name_id_t = 65535;
 /// hb_ot_name_id_t:
 /// @HB_OT_NAME_ID_INVALID: Value to represent a nonexistent name ID.
 ///
@@ -2971,7 +2971,6 @@ pub const HB_OT_NAME_ID_INVALID: _bindgen_ty_1 = 65535;
 /// API.  These can be used to fetch name strings from a font face.
 ///
 /// Since: 2.0.0
-pub type _bindgen_ty_1 = u32;
 pub type hb_ot_name_id_t = ::std::os::raw::c_uint;
 /// hb_ot_name_entry_t:
 /// @name_id: name ID
@@ -3790,9 +3789,9 @@ pub struct hb_ot_var_axis_info_t {
     pub tag: hb_tag_t,
     pub name_id: hb_ot_name_id_t,
     pub flags: hb_ot_var_axis_flags_t,
-    pub min_value: f32,
-    pub default_value: f32,
-    pub max_value: f32,
+    pub min_value: ::std::os::raw::c_float,
+    pub default_value: ::std::os::raw::c_float,
+    pub max_value: ::std::os::raw::c_float,
     pub reserved: ::std::os::raw::c_uint,
 }
 #[test]
@@ -3927,7 +3926,7 @@ extern "C" {
         face: *mut hb_face_t,
         instance_index: ::std::os::raw::c_uint,
         coords_length: *mut ::std::os::raw::c_uint,
-        coords: *mut f32,
+        coords: *mut ::std::os::raw::c_float,
     ) -> ::std::os::raw::c_uint;
 }
 extern "C" {
@@ -3943,7 +3942,7 @@ extern "C" {
     pub fn hb_ot_var_normalize_coords(
         face: *mut hb_face_t,
         coords_length: ::std::os::raw::c_uint,
-        design_coords: *const f32,
+        design_coords: *const ::std::os::raw::c_float,
         normalized_coords: *mut ::std::os::raw::c_int,
     );
 }


### PR DESCRIPTION
This adds a crate to the workspace for testing `harfbuzz-sys` automatically using `ctest`.

I changed a few types in `harfbuzz-sys/src/lib.rs` to make the testing automatic (i.e. to avoid creating special cases). However, I suppose `lib.rs` is generated? If so, this might be problematic if it is regenerated later. The changes seem quite sensible to me, so maybe there's an alternative to tweak the generation to get something similar?

`harfbuzz-sys-test` currently only works with `HARFBUZZ_SYS_NO_PKG_CONFIG=1` because it doesn't get the `DEP_HARFBUZZ_INCLUDE` environment variable otherwise. The `.travis.yml` change reflects that. If #139 or something similar is merged, this special case can be removed, and the test should be run for both `HARFBUZZ_SYS_NO_PKG_CONFIG=1` and without `HARFBUZZ_SYS_NO_PKG_CONFIG`.

There's a `FIXME` in `harfbuzz-sys-test/build.rs` because I don't understand the errors when these functions are not skipped. I would appreciate it if someone else would take a look at that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/140)
<!-- Reviewable:end -->
