### PR TITLE
Exclude only test font data

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -12,7 +12,11 @@ keywords = ["opentype", "font", "text", "layout", "unicode"]
 categories = ["external-ffi-bindings", "internationalization"]
 
 exclude = [
-    "harfbuzz/test/*"
+    "harfbuzz/test/subset/data/fonts/*",
+    "harfbuzz/test/fuzzing/fonts/*",
+    "harfbuzz/test/shaping/data/text-rendering-tests/fonts/*",
+    "harfbuzz/test/shaping/data/aots/fonts/*",
+    "harfbuzz/test/shaping/data/in-house/fonts/*",
 ]
 
 links = "harfbuzz"


### PR DESCRIPTION
This is a key part taken from #138 and #142. I'm creating a new PR here for just this since those others have been combined with other, somewhat orthogonal issues. I think it's best to go ahead and merge this and make a release, since this issue is affecting others. I'll continue working on the other issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/144)
<!-- Reviewable:end -->
