### PR TITLE
Avoid source changes during static build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,7 @@ matrix:
         # Test the harfbuzz-sys package build to check the 'exclude's. We should
         # do this where the embedded harfbuzz is statically linked, but we don't
         # need to do it for every environment.
-        #
-        # FIXME: We use --no-verify to disable strange errors about build
-        # scripts modifying files that don't seem to affect the resulting crate.
-        # Try again when cargo 1.35 is released, since it uses a different
-        # fingerprinting mechanism.
-        - cargo package --manifest-path=harfbuzz-sys/Cargo.toml --no-verify
+        - cargo package --manifest-path=harfbuzz-sys/Cargo.toml
 
     - name: stable, macOS, shared library
       os: osx

--- a/harfbuzz-sys/makefile.cargo
+++ b/harfbuzz-sys/makefile.cargo
@@ -36,12 +36,20 @@ CONFIGURE_FLAGS = \
 	--without-glib \
 	--with-coretext=auto
 
+# Create a unique temporary build directory
+BUILD_DIR := $(shell mktemp -d $(OUT_DIR)/rust_build.XXXXX)
+
 all:
-	$(MAKE) -f $(CARGO_MANIFEST_DIR)/makefile.touch touch \
-	  HARFBUZZ=$(CARGO_MANIFEST_DIR)/harfbuzz
-	cd $(OUT_DIR) && $(CARGO_MANIFEST_DIR)/harfbuzz/configure $(CONFIGURE_FLAGS) \
-	  CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)"
-	cd $(OUT_DIR) && make -j$(NUM_JOBS)
-	cd $(OUT_DIR) && make install
+	# Copy source files to BUILD_DIR to avoid changing originals.
+	cp -a $(CARGO_MANIFEST_DIR)/harfbuzz/* $(BUILD_DIR)
+	# Touch in BUILD_DIR avoid regenerating files.
+	$(MAKE) -f $(CARGO_MANIFEST_DIR)/makefile.touch touch HARFBUZZ="$(BUILD_DIR)"
+	# Configure and build in BUILD_DIR, install from BUILD_DIR into OUT_DIR.
+	cd $(BUILD_DIR) && \
+	  ./configure $(CONFIGURE_FLAGS) CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" && \
+	  make -j$(NUM_JOBS) && \
+	  make install
+	# Remove the no-longer-needed BUILD_DIR to save space.
+	rm -rf $(BUILD_DIR)
 
 .PHONY: all


### PR DESCRIPTION
`cargo package` sporadically complains about file modifications outside `OUT_DIR`. See https://github.com/servo/rust-harfbuzz/pull/142 for an experiment with chasing down that issue, which can involve different files changed at different times.

The build script is written to build out-of-tree in `OUT_DIR`, but `configure` and/or `make` still modify the source tree.

This change involves creating a temporary `BUILD_DIR` in `OUT_DIR`, copying the source files there, building, installing into `OUT_DIR`, and, finally, removing `BUILD_DIR`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/147)
<!-- Reviewable:end -->
