### PR TITLE
Don't print cargo:include= with pkg-config

### DIFF
--- a/harfbuzz-sys-test/build.rs
+++ b/harfbuzz-sys-test/build.rs
@@ -7,11 +7,9 @@ fn main() {
     let mut cfg = ctest::TestGenerator::new();
 
     // Get the include paths from harfbuzz-sys or pkg-config.
-    if let Some(include_paths) = &env::var_os("DEP_HARFBUZZ_INCLUDE") {
-        // These come from a static build in harfbuzz-sys.
-        for path in env::split_paths(include_paths) {
-            cfg.include(path);
-        }
+    if let Some(path) = &env::var_os("DEP_HARFBUZZ_INCLUDE") {
+        // This comes from a static build in harfbuzz-sys.
+        cfg.include(path);
     } else if let Ok(lib) = pkg_config::probe_library("harfbuzz") {
         // These come from pkg-config.
         for path in lib.include_paths {

--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -11,18 +11,7 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=HARFBUZZ_SYS_NO_PKG_CONFIG");
     if env::var_os("HARFBUZZ_SYS_NO_PKG_CONFIG").is_none() {
-        if let Ok(lib) = pkg_config::probe_library("harfbuzz") {
-            // Avoid printing an empty value
-            if !lib.include_paths.is_empty() {
-                // DEP_HARFBUZZ_INCLUDE has the paths of harfbuzz and dependencies.
-                println!(
-                    "cargo:include={}",
-                    env::join_paths(lib.include_paths)
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                );
-            }
+        if pkg_config::probe_library("harfbuzz").is_ok() {
             return;
         }
     }


### PR DESCRIPTION
I introduced this in 692048e56a66afc36d4a6ef261ed2965bdcdf30a, but it's the wrong thing to do. When a dependent crate gets the `pkg-config` include paths in `DEP_HARFBUZZ_INCLUDE`, it may also need other aspects such as the link paths, but it doesn't know that information is available from `pkg-config`. So, the dependent crate must assume that, if `DEP_HARFBUZZ_INCLUDE` is not available, it should use `pkg-config`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/148)
<!-- Reviewable:end -->
