### PR TITLE
Preliminary build support for WebAssembly.

### DIFF
--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -9,8 +9,10 @@ fn main() {
     use std::process::Command;
     use std::path::PathBuf;
 
+    let target = env::var("TARGET").unwrap();
+
     println!("cargo:rerun-if-env-changed=HARFBUZZ_SYS_NO_PKG_CONFIG");
-    if env::var_os("HARFBUZZ_SYS_NO_PKG_CONFIG").is_none() {
+    if target.contains("wasm32") || env::var_os("HARFBUZZ_SYS_NO_PKG_CONFIG").is_none() {
         if pkg_config::probe_library("harfbuzz").is_ok() {
             return;
         }
@@ -21,9 +23,18 @@ fn main() {
     // On Windows, HarfBuzz configures atomics directly; otherwise,
     // it needs assistance from configure to do so.  Just use the makefile
     // build for now elsewhere.
-    let target = env::var("TARGET").unwrap();
-    if target.contains("windows") {
-        let dst = cmake::Config::new("harfbuzz").build();
+    if target.contains("windows") || target.contains("wasm32") {
+        let mut cfg = cmake::Config::new("harfbuzz");
+        if target.contains("wasm") {
+            // When building on macOS for wasm32, make sure we aren't picking up
+            // CoreText.
+            cfg.define("HB_HAVE_CORETEXT", "OFF");
+            if target == "wasm32-unknown-unknown" {
+                // Switch to the correct target triple for the underlying toolchain.
+                cfg.target("wasm32-unknown-none");
+            }
+        }
+        let dst = cfg.build();
         println!("cargo:rustc-link-search=native={}/lib", dst.display());
         println!("cargo:rustc-link-lib=static=harfbuzz");
         if target.contains("gnu") {


### PR DESCRIPTION
This supports building harfbuzz-sys for WebAssembly using:

    --target wasm32-unknown-unknown --features=build-native-harfbuzz

Building with emscripten may or may not work yet.

This is progress on issue #153.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/155)
<!-- Reviewable:end -->
