### PR TITLE
Update homebrew on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
         homebrew:
           packages:
             - harfbuzz
+          update: true
 
     - name: stable, macOS, static linking
       os: osx


### PR DESCRIPTION
This is required to get the current versions of Harfbuzz that are
bundled, so that ctest will check against those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/163)
<!-- Reviewable:end -->
