### PR TITLE
Remove TravisCI build against homebrew.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,17 +52,6 @@ matrix:
         # need to do it for every environment.
         - cargo package --manifest-path=harfbuzz-sys/Cargo.toml
 
-    - name: stable, macOS, shared library
-      os: osx
-      # Use this image to get harfbuzz > 2. Older images have an older version
-      # of harfbuzz.
-      osx_image: xcode10.2
-      rust: stable
-      addons:
-        homebrew:
-          packages:
-            - harfbuzz
-
     - name: stable, macOS, static linking
       os: osx
       rust: stable


### PR DESCRIPTION
This isn't something that people would ship, so there isn't
much point in testing it. This creates problems for the ctest
usage in homebrew-sys-test when the version of Harfbuzz being
bound isn't the same as in Homebrew.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/164)
<!-- Reviewable:end -->
