### PR TITLE
Improve deps for Apple platforms.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -26,12 +26,12 @@ build = "build.rs"
 pkg-config = { version = "0.3", optional = true }
 cmake = { version = "0.1", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 core-graphics = "0.17"
 core-text = "13"
 foreign-types = "0.3"
 
-[target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
+[target.'cfg(any(target_os = "android", all(unix, not(target_vendor = "apple"))))'.dependencies]
 freetype = { version = "0.4", default-features = false }
 
 [features]

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -1,13 +1,13 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::unreadable_literal)]
 
-#[cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))]
+#[cfg(any(target_os = "android", all(unix, not(target_vendor = "apple"))))]
 extern crate freetype;
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 pub mod coretext;
 
-#[cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))]
+#[cfg(any(target_os = "android", all(unix, not(target_vendor = "apple"))))]
 extern "C" {
     pub fn hb_ft_font_create_referenced(face: freetype::freetype::FT_Face) -> *mut hb_font_t;
 }


### PR DESCRIPTION
For all Apple platforms, we want to be linking against CoreFoundation
and CoreText, and not FreeType.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-harfbuzz/169)
<!-- Reviewable:end -->
