### PR TITLE
Never run ragel when generated files exist

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.3.2"
+version = "0.3.3"
 
 authors = ["The Servo Project Developers"]
 license = "MIT"

--- a/harfbuzz-sys/makefile.touch
+++ b/harfbuzz-sys/makefile.touch
@@ -33,6 +33,12 @@ TOUCH_FILES = $(wildcard \
 	$(HARFBUZZ)/src/hb-version.* \
 	)
 
+# Avoid requiring Ragel to be installed: https://github.com/servo/servo/issues/24611
+TOUCH_FILES += $(wildcard \
+	$(HARFBUZZ)/src/*.rl \
+	$(HARFBUZZ)/src/*.hh \
+)
+
 touch:
 	touch -r $(HARFBUZZ)/configure $(TOUCH_FILES)
 


### PR DESCRIPTION
This is untested, but hopefully works around https://github.com/servo/servo/issues/24611.

This is not suitable for development of Harfbuzz itself (as opposed to bindings), but hopefully that doesn’t happen in this repository and being required to run `cargo clean` after updating the Harfbuzz version is acceptable.