### PR TITLE
Add -mbig-obj flag when building harfbuzz on windows-gnu

### DIFF
--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -30,6 +30,10 @@ fn main() {
     if target.contains("apple") {
         cfg.define("HAVE_CORETEXT", "1");
     }
+    
+    if target.contains("windows-gnu") {
+        cfg.flag("-Wa,-mbig-obj");
+    }
 
     cfg.compile("embedded_harfbuzz");
 


### PR DESCRIPTION
When building on window-gnu targets I was getting "file too big errors" in harfbuzz-sys. This adds the assembler flag -mbig-obj on windows-gnu targets which fixes the error, based on the advice [here](https://digitalkarabela.com/mingw-w64-how-to-fix-file-too-big-too-many-sections/). I have tested this with both the x86_64-pc-windows-gnu and i686-pc-windows-gnu targets.