### PR TITLE
Upgrade core libs

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -27,8 +27,8 @@ pkg-config = { version = "0.3", optional = true }
 cc = { version = "1", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-core-graphics = "0.17"
-core-text = "13"
+core-graphics = ">=0.19"
+core-text = ">=15"
 foreign-types = "0.3"
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_vendor = "apple"))))'.dependencies]

--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -27,8 +27,8 @@ pkg-config = { version = "0.3", optional = true }
 cc = { version = "1", optional = true }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-core-graphics = ">=0.19"
-core-text = ">=15"
+core-graphics = "0.19"
+core-text = "15"
 foreign-types = "0.3"
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_vendor = "apple"))))'.dependencies]


### PR DESCRIPTION
This allows coverage using lcov and grcov. Related to this issue https://github.com/servo/core-foundation-rs/pull/357