### PR TITLE
Update to freetype 0.5

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.3.4"
+version = "0.4.0"
 
 authors = ["The Servo Project Developers"]
 license = "MIT"
@@ -32,9 +32,9 @@ core-text = "15"
 foreign-types = "0.3"
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_vendor = "apple"))))'.dependencies]
-freetype = { version = "0.4", default-features = false }
+freetype = { version = "0.5", default-features = false }
 
 [features]
 default = ["build-native-harfbuzz", "build-native-freetype"]
 build-native-harfbuzz = ["cc", "pkg-config"]
-build-native-freetype = ["freetype/servo-freetype-sys"]
+build-native-freetype = ["freetype/freetype-sys"]

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["opentype", "font", "text", "layout", "unicode"]
 
 [dependencies.harfbuzz-sys]
 path = "../harfbuzz-sys"
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [features]


### PR DESCRIPTION
Therefore change feature name to match upstream's:
https://github.com/servo/rust-freetype/commit/342ad76e12b9792bf400a11a749032274188605b

Also bump version of harfbuzz-sys to 0.4 like in PR #107.