### PR TITLE
harfbuzz-sys: Exclude more from published package.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -13,11 +13,10 @@ keywords = ["opentype", "font", "text", "layout", "unicode"]
 categories = ["external-ffi-bindings", "internationalization"]
 
 exclude = [
-    "harfbuzz/test/subset/data/fonts/*",
-    "harfbuzz/test/fuzzing/fonts/*",
-    "harfbuzz/test/shaping/data/text-rendering-tests/fonts/*",
-    "harfbuzz/test/shaping/data/aots/fonts/*",
-    "harfbuzz/test/shaping/data/in-house/fonts/*",
+    "harfbuzz/docs/*",
+    "harfbuzz/subprojects/benchmark-1.5.2/*",
+    "harfbuzz/test/*",
+    "update.sh",
 ]
 
 links = "harfbuzz"


### PR DESCRIPTION
We shouldn't need any of the test stuff, the benchmark library, or docs from harfbuzz in the package on crates.io.

The previous exclusion block was very incomplete for the version of harfbuzz provided.