### PR TITLE
Move freetype binding to separate module.

### DIFF
--- a/harfbuzz-sys/src/freetype.rs
+++ b/harfbuzz-sys/src/freetype.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::hb_font_t;
+
+extern "C" {
+    /// This requires that the `freetype` feature is enabled.
+    pub fn hb_ft_font_create_referenced(face: freetype::freetype::FT_Face) -> *mut hb_font_t;
+}

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -18,10 +18,7 @@ pub mod coretext;
 pub mod directwrite;
 
 #[cfg(feature = "freetype")]
-extern "C" {
-    /// This requires that the `freetype` feature is enabled.
-    pub fn hb_ft_font_create_referenced(face: freetype::freetype::FT_Face) -> *mut hb_font_t;
-}
+pub mod freetype;
 
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]


### PR DESCRIPTION
This makes it more like the others, and will keep it cleaner when we go and bind the other functions in this module.