### PR TITLE
Use `bundled` feature to use our own copy of harfbuzz.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,6 @@ jobs:
   linux-ci-static:
     name: stable, Linux, static linking, no pkg-config
     runs-on: ubuntu-latest
-    env:
-      HARFBUZZ_SYS_NO_PKG_CONFIG: 1
     steps:
       - uses: actions/checkout@v3
 
@@ -60,13 +58,13 @@ jobs:
       # do this where the embedded harfbuzz is statically linked, but we don't
       # need to do it for every environment.
       - name: Cargo package
-        run: cargo package --manifest-path=harfbuzz-sys/Cargo.toml
+        run: cargo package --manifest-path=harfbuzz-sys/Cargo.toml --features bundled
 
       - name: Cargo build
-        run: cargo build --workspace
+        run: cargo build --workspace --features bundled
 
       - name: Cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --features bundled
         env:
           RUST_BACKTRACE: 1
 
@@ -100,8 +98,6 @@ jobs:
   mac-ci-static:
     name: stable, macOS, static library
     runs-on: macos-latest
-    env:
-      HARFBUZZ_SYS_NO_PKG_CONFIG: 1
 
     steps:
       - uses: actions/checkout@v3
@@ -115,10 +111,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Cargo build
-        run: cargo build --workspace
+        run: cargo build --workspace --features bundled
 
       - name: Cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --features bundled
         env:
           RUST_BACKTRACE: 1
 
@@ -133,10 +129,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cargo build
-        run: cargo build --workspace
+        run: cargo build --workspace --features bundled
 
       - name: Cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --features bundled
         env:
           RUST_BACKTRACE: 1
 
@@ -157,7 +153,7 @@ jobs:
           target: wasm32-unknown-emscripten
 
       - name: Cargo build
-        run: cargo build --target wasm32-unknown-emscripten --workspace --no-default-features --features build-native-harfbuzz
+        run: cargo build --target wasm32-unknown-emscripten --workspace --no-default-features --features bundled
 
   ios-ci-static:
     name: stable, iOS, static library
@@ -172,7 +168,7 @@ jobs:
           target: aarch64-apple-ios
 
       - name: Cargo build
-        run: cargo build --target aarch64-apple-ios --workspace --no-default-features --features "build-native-harfbuzz, coretext"
+        run: cargo build --target aarch64-apple-ios --workspace --no-default-features --features "bundled, coretext"
 
   build_result:
     name: Result

--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -24,8 +24,8 @@ links = "harfbuzz"
 build = "build.rs"
 
 [build-dependencies]
-pkg-config = { version = "0.3", optional = true }
-cc = { version = "1", optional = true }
+pkg-config = { version = "0.3" }
+cc = { version = "1" }
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 core-graphics = { version = "0.22", optional = true }
@@ -42,7 +42,7 @@ version = "0.7"
 optional = true
 
 [features]
-default = ["build-native-harfbuzz", "coretext", "directwrite", "freetype"]
+default = ["coretext", "directwrite", "freetype"]
+bundled = []
 coretext = ["core-graphics", "core-text", "foreign-types"]
 directwrite = ["winapi"]
-build-native-harfbuzz = ["cc", "pkg-config"]

--- a/harfbuzz-sys/README.md
+++ b/harfbuzz-sys/README.md
@@ -20,6 +20,8 @@ This crate provides low-level bindings to the C API.
 - `coretext` - Enables bindings to the CoreText font engine. (Apple platforms only) (Enabled by default.)
 - `directwrite` - Enables bindings to the DirectWrite font engine. (Windows only) (Enabled by default.)
 
+- `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
+
 ## License
 
 Licensed under the MIT license ([LICENSE](LICENSE) or <https://opensource.org/licenses/MIT>).

--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -1,16 +1,8 @@
-#[cfg(feature = "build-native-harfbuzz")]
-fn main() {
+fn build_harfbuzz() {
     use std::env;
     use std::path::PathBuf;
 
     let target = env::var("TARGET").unwrap();
-
-    println!("cargo:rerun-if-env-changed=HARFBUZZ_SYS_NO_PKG_CONFIG");
-    if (target.contains("wasm32") || env::var_os("HARFBUZZ_SYS_NO_PKG_CONFIG").is_none())
-        && pkg_config::probe_library("harfbuzz").is_ok()
-    {
-        return;
-    }
 
     let mut cfg = cc::Build::new();
     cfg.cpp(true)
@@ -44,5 +36,11 @@ fn main() {
     );
 }
 
-#[cfg(not(feature = "build-native-harfbuzz"))]
-fn main() {}
+fn main() {
+    if cfg!(feature = "bundled") {
+        build_harfbuzz();
+    } else {
+        // Use the pre-installed harfbuzz.
+        pkg_config::probe_library("harfbuzz").unwrap();
+    }
+}

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -8,6 +8,8 @@
 //! - `freetype` - Enables bindings to the FreeType font engine. (Enabled by default.)
 //! - `coretext` - Enables bindings to the CoreText font engine. (Apple platforms only) (Enabled by default.)
 //! - `directwrite` - Enables bindings to the DirectWrite font engine. (Windows only) (Enabled by default.)
+//!
+//! - `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
 
 #[cfg(all(target_vendor = "apple", feature = "coretext"))]
 pub mod coretext;

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -19,8 +19,8 @@ version = "0.5.0"
 default-features = false
 
 [features]
-default = ["build-native-harfbuzz", "coretext", "directwrite", "freetype"]
-build-native-harfbuzz = ["harfbuzz-sys/build-native-harfbuzz"]
+default = ["coretext", "directwrite", "freetype"]
+bundled = ["harfbuzz-sys/bundled"]
 coretext = ["harfbuzz-sys/coretext"]
 directwrite = ["harfbuzz-sys/directwrite"]
 freetype = ["harfbuzz-sys/freetype"]

--- a/harfbuzz/README.md
+++ b/harfbuzz/README.md
@@ -21,6 +21,8 @@ This crate provides a higher level API (than the
 - `coretext` - Enables bindings to the CoreText font engine. (Apple platforms only) (Enabled by default.)
 - `directwrite` - Enables bindings to the DirectWrite font engine. (Windows only) (Enabled by default.)
 
+- `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
+
 ## License
 
 Licensed under either of

--- a/harfbuzz/src/lib.rs
+++ b/harfbuzz/src/lib.rs
@@ -15,6 +15,8 @@
 //! - `freetype` - Enables bindings to the FreeType font engine. (Enabled by default.)
 //! - `coretext` - Enables bindings to the CoreText font engine. (Apple platforms only) (Enabled by default.)
 //! - `directwrite` - Enables bindings to the DirectWrite font engine. (Windows only) (Enabled by default.)
+//!
+//! - `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
 
 #![warn(missing_docs)]
 #![deny(


### PR DESCRIPTION
This looks for one installed on the system by default. It can be forced to look on the system even if `bundled` is set by defining `HARFBUZZ_SYS_USE_PKG_CONFIG` in the environment to `"1"`.

If `bundled` is set, then it will use the sources that we vendor.

In general, `bundled` should be set as needed by applications rather than by libraries using `harfbuzz` or `harfbuzz-sys`. This allows for control by the application's build since once the feature is enabled by a crate, it can't readily be disabled.

The name for the `bundled` feature comes from the rusqlite bindings for `libsqlite-sys`.