### PR TITLE
Make harfbuzz and harfbuzz-sys no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,11 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - name: Cargo check no-default-features
+        run: cargo check --no-default-features
+        env:
+          RUST_BACKTRACE: 1
+
   linux-ci-static:
     name: stable, Linux, static linking, no pkg-config
     runs-on: ubuntu-latest

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -20,6 +20,8 @@
 //!
 //! - `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
 
+#![no_std]
+
 #[cfg(all(target_vendor = "apple", feature = "coretext"))]
 pub mod coretext;
 

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -19,8 +19,9 @@ version = "0.5.0"
 default-features = false
 
 [features]
-default = ["coretext", "directwrite", "freetype"]
+default = ["coretext", "directwrite", "freetype", "std"]
 bundled = ["harfbuzz-sys/bundled"]
 coretext = ["harfbuzz-sys/coretext"]
 directwrite = ["harfbuzz-sys/directwrite"]
 freetype = ["harfbuzz-sys/freetype"]
+std = []

--- a/harfbuzz/src/blob.rs
+++ b/harfbuzz/src/blob.rs
@@ -8,10 +8,12 @@
 // except according to those terms.
 
 use crate::sys;
-use std::marker::PhantomData;
-use std::os::raw::{c_char, c_uint, c_void};
-use std::sync::Arc;
-use std::{mem, ops, ptr, slice};
+use core::ffi::{c_char, c_uint};
+use core::marker::PhantomData;
+use core::{mem, ops, ptr, slice};
+
+#[cfg(feature = "std")]
+use std::{ffi::c_void, sync::Arc, vec::Vec};
 
 /// Blobs wrap a chunk of binary data to handle lifecycle management of data
 /// while it is passed between client and HarfBuzz.
@@ -55,6 +57,8 @@ impl<'a> Blob<'a> {
     /// data may be shared by Rust code and the blob. The `Vec` is freed
     /// when all references are dropped.
     ///
+    /// ✨ *Enabled with the `std` Cargo feature.*
+    ///
     /// ```
     /// # use std::sync::Arc;
     /// # use harfbuzz::Blob;
@@ -63,6 +67,7 @@ impl<'a> Blob<'a> {
     /// assert_eq!(blob.len(), 256);
     /// assert!(!blob.is_empty());
     /// ```
+    #[cfg(feature = "std")]
     pub fn new_from_arc_vec(data: Arc<Vec<u8>>) -> Blob<'static> {
         let len = data.len();
         assert!(len <= c_uint::max_value() as usize);

--- a/harfbuzz/src/buffer.rs
+++ b/harfbuzz/src/buffer.rs
@@ -99,7 +99,7 @@ impl Buffer {
     /// Gives up ownership and returns a raw pointer to the buffer.
     pub fn into_raw(self) -> *mut sys::hb_buffer_t {
         let raw = self.raw;
-        std::mem::forget(self);
+        core::mem::forget(self);
         raw
     }
 
@@ -122,10 +122,10 @@ impl Buffer {
         unsafe {
             sys::hb_buffer_add_utf8(
                 self.raw,
-                text.as_ptr() as *const std::os::raw::c_char,
-                text.len() as std::os::raw::c_int,
+                text.as_ptr() as *const core::ffi::c_char,
+                text.len() as core::ffi::c_int,
                 0,
-                text.len() as std::os::raw::c_int,
+                text.len() as core::ffi::c_int,
             )
         };
     }
@@ -144,8 +144,8 @@ impl Buffer {
             sys::hb_buffer_append(
                 self.raw,
                 other.raw,
-                start as std::os::raw::c_uint,
-                end as std::os::raw::c_uint,
+                start as core::ffi::c_uint,
+                end as core::ffi::c_uint,
             )
         };
     }
@@ -297,8 +297,8 @@ impl Buffer {
     }
 }
 
-impl std::fmt::Debug for Buffer {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for Buffer {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         fmt.debug_struct("Buffer")
             .field("direction", &self.get_direction())
             .field("script", &self.get_script())

--- a/harfbuzz/src/language.rs
+++ b/harfbuzz/src/language.rs
@@ -26,15 +26,15 @@ impl Language {
         Language {
             raw: unsafe {
                 sys::hb_language_from_string(
-                    lang.as_ptr() as *const std::os::raw::c_char,
-                    lang.len() as std::os::raw::c_int,
+                    lang.as_ptr() as *const core::ffi::c_char,
+                    lang.len() as core::ffi::c_int,
                 )
             },
         }
     }
 
     pub fn to_string(&self) -> &str {
-        unsafe { std::ffi::CStr::from_ptr(sys::hb_language_to_string(self.raw)) }
+        unsafe { core::ffi::CStr::from_ptr(sys::hb_language_to_string(self.raw)) }
             .to_str()
             .unwrap()
     }
@@ -63,8 +63,8 @@ impl Language {
     }
 }
 
-impl std::fmt::Debug for Language {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for Language {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         fmt.write_str(self.to_string())
     }
 }

--- a/harfbuzz/src/lib.rs
+++ b/harfbuzz/src/lib.rs
@@ -15,9 +15,11 @@
 //! - `freetype` - Enables bindings to the FreeType font engine. (Enabled by default.)
 //! - `coretext` - Enables bindings to the CoreText font engine. (Apple platforms only) (Enabled by default.)
 //! - `directwrite` - Enables bindings to the DirectWrite font engine. (Windows only) (Enabled by default.)
+//! - `std` - Enable certain functions that require the standard library. (Enabled by default.)
 //!
 //! - `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
 
+#![no_std]
 #![warn(missing_docs)]
 #![deny(
     trivial_numeric_casts,
@@ -25,6 +27,11 @@
     unused_import_braces,
     unused_qualifications
 )]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub use harfbuzz_sys as sys;
 


### PR DESCRIPTION
Adds a `std` feature, enabled by default, to `harfbuzz` to enable one API that needs `std::sync::Arc`.