### PR TITLE
bundled: Obey coretext, directwrite features when configuring harfbuzz.

### DIFF
--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -23,11 +23,11 @@ fn build_harfbuzz() {
         cfg.define("HAVE_PTHREAD", "1");
     }
 
-    if target.contains("apple") {
+    if target.contains("apple") && cfg!(feature = "coretext") {
         cfg.define("HAVE_CORETEXT", "1");
     }
 
-    if target.contains("windows") {
+    if target.contains("windows") && cfg!(feature = "directwrite") {
         cfg.define("HAVE_DIRECTWRITE", "1");
     }
 


### PR DESCRIPTION
When we build a bundled `harfbuzz`, only enable `HAVE_CORETEXT` and `HAVE_DIRECTWRITE` when the corresponding features are set.

We don't correct `HAVE_FREETYPE` here as it has other larger issues that need to be resolved first.