### PR TITLE
Use `freetype-sys` rather than Servo's `freetype`.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -37,8 +37,8 @@ version = "0.3"
 optional = true
 features = ["dwrite"]
 
-[dependencies.freetype]
-version = "0.7"
+[dependencies.freetype-sys]
+version = "0.18"
 optional = true
 
 [features]
@@ -46,3 +46,4 @@ default = ["coretext", "directwrite", "freetype"]
 bundled = []
 coretext = ["core-graphics", "core-text", "foreign-types"]
 directwrite = ["winapi"]
+freetype = ["freetype-sys"]

--- a/harfbuzz-sys/src/freetype.rs
+++ b/harfbuzz-sys/src/freetype.rs
@@ -11,5 +11,5 @@ use crate::hb_font_t;
 
 extern "C" {
     /// This requires that the `freetype` feature is enabled.
-    pub fn hb_ft_font_create_referenced(face: freetype::freetype::FT_Face) -> *mut hb_font_t;
+    pub fn hb_ft_font_create_referenced(face: freetype_sys::FT_Face) -> *mut hb_font_t;
 }


### PR DESCRIPTION
This simplifies the dependency graph as we weren't getting anything from using the Servo `freetype` crate here as it also built and depended upon `freetype-sys`.

Fixes #238.