### PR TITLE
Avoid doc-markdown lints.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["CoreText", "DirectWrite", "FreeType", "HarfBuzz", "OpenType", ".."]

--- a/harfbuzz-sys/src/lib.rs
+++ b/harfbuzz-sys/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
 
 #![no_std]
+#![warn(clippy::doc_markdown)]
 
 #[cfg(all(target_vendor = "apple", feature = "coretext"))]
 pub mod coretext;

--- a/harfbuzz/src/lib.rs
+++ b/harfbuzz/src/lib.rs
@@ -20,7 +20,7 @@
 //! - `bundled` - Use the bundled copy of the harfbuzz library rather than one installed on the system.
 
 #![no_std]
-#![warn(missing_docs)]
+#![warn(clippy::doc_markdown, missing_docs)]
 #![deny(
     trivial_numeric_casts,
     unstable_features,


### PR DESCRIPTION
* Add some valid words that aren't identifiers to clippy.toml to avoid warnings about the use of these terms not being within backticks.
* Enable the warning for `clippy::doc_markdown` so that it gets maintained cleanly going forward.