### PR TITLE
dependencies: Upgrade to the latest version of freetype-sys

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -38,7 +38,7 @@ optional = true
 features = ["dwrite"]
 
 [dependencies.freetype-sys]
-version = "0.18"
+version = "0.19"
 optional = true
 
 [features]


### PR DESCRIPTION
This is in preparation for the 0.6.0 release.
