### PR TITLE
Bump `harfbuzz` and `harfbuzz-sys` versions.

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 authors = ["The Servo Project Developers"]

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 authors = ["The Servo Project Developers"]
@@ -15,7 +15,7 @@ categories = ["text-processing"]
 
 [dependencies.harfbuzz-sys]
 path = "../harfbuzz-sys"
-version = "0.5.0"
+version = "0.6.0"
 default-features = false
 
 [dependencies.harfbuzz-traits]


### PR DESCRIPTION
`harfbuzz-traits` won't get bumped yet as it hasn't been published.

Supercedes #245.