### PR TITLE
Make Cargo.toml respect crates.io keyword limit

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "Rust bindings to the HarfBuzz text shaping engine"
 repository = "https://github.com/servo/rust-harfbuzz"
 documentation = "https://docs.rs/harfbuzz-sys/"
-keywords = ["opentype", "font", "text", "layout", "unicode", "shaping"]
+keywords = ["opentype", "font", "text", "unicode", "shaping"]
 categories = ["external-ffi-bindings", "internationalization", "text-processing"]
 
 exclude = [

--- a/harfbuzz-traits/Cargo.toml
+++ b/harfbuzz-traits/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "Rust Traits for the HarfBuzz text shaping engine"
 repository = "https://github.com/servo/rust-harfbuzz"
 documentation = "https://docs.rs/harfbuzz/"
-keywords = ["opentype", "font", "text", "layout", "unicode", "shaping"]
+keywords = ["opentype", "font", "text", "unicode", "shaping"]
 categories = ["text-processing"]
 
 [features]

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "Rust bindings to the HarfBuzz text shaping engine"
 repository = "https://github.com/servo/rust-harfbuzz"
 documentation = "https://docs.rs/harfbuzz/"
-keywords = ["opentype", "font", "text", "layout", "unicode", "shaping"]
+keywords = ["opentype", "font", "text", "unicode", "shaping"]
 categories = ["text-processing"]
 
 [dependencies.harfbuzz-sys]


### PR DESCRIPTION
There is a 5 keyword limit.
