### PR TITLE
Release a version 0.6.1 of `harfbuzz` and consolidate Cargo configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
 [workspace]
 resolver = "2"
 members = ["harfbuzz", "harfbuzz-sys", "harfbuzz-traits"]
+
+[workspace.package]
+edition = "2021"
+authors = ["The Servo Project Developers"]
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/harfbuzz/"
+keywords = ["opentype", "font", "text", "unicode", "shaping"]
+categories = ["text-processing"]
+repository = "https://github.com/servo/rust-harfbuzz"

--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.6.0"
-edition = "2021"
-
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
+version = "0.6.1"
 readme = "README.md"
-
-description = "Rust bindings to the HarfBuzz text shaping engine"
-repository = "https://github.com/servo/rust-harfbuzz"
-documentation = "https://docs.rs/harfbuzz-sys/"
-keywords = ["opentype", "font", "text", "unicode", "shaping"]
 categories = ["external-ffi-bindings", "internationalization", "text-processing"]
+description = "Rust bindings to the HarfBuzz text shaping engine"
+
+authors = { workspace = true }
+documentation = { workspace = true }
+edition = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 exclude = [
     "harfbuzz/docs/*",

--- a/harfbuzz-traits/Cargo.toml
+++ b/harfbuzz-traits/Cargo.toml
@@ -1,16 +1,12 @@
 [package]
 name = "harfbuzz-traits"
 version = "0.6.0"
-edition = "2021"
+description = "Rust traits for the HarfBuzz text shaping engine bindings"
 
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-
-description = "Rust Traits for the HarfBuzz text shaping engine"
-repository = "https://github.com/servo/rust-harfbuzz"
-documentation = "https://docs.rs/harfbuzz/"
-keywords = ["opentype", "font", "text", "unicode", "shaping"]
-categories = ["text-processing"]
-
-[features]
+authors = { workspace = true }
+categories = { workspace = true }
+documentation = { workspace = true }
+edition = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "harfbuzz"
 version = "0.6.0"
-edition = "2021"
-
-authors = ["The Servo Project Developers"]
-license = "MIT OR Apache-2.0"
 readme = "README.md"
+description = "High-level Rust bindings to the HarfBuzz text shaping engine"
 
-description = "Rust bindings to the HarfBuzz text shaping engine"
-repository = "https://github.com/servo/rust-harfbuzz"
-documentation = "https://docs.rs/harfbuzz/"
-keywords = ["opentype", "font", "text", "unicode", "shaping"]
-categories = ["text-processing"]
+authors = { workspace = true }
+categories = { workspace = true }
+documentation = { workspace = true }
+edition = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies.harfbuzz-sys]
 path = "../harfbuzz-sys"
-version = "0.6.0"
+version = "0.6.1"
 default-features = false
 
 [dependencies.harfbuzz-traits]


### PR DESCRIPTION
I managed to publish this crate without checking out the git submodules
first, which breaks the `bundled` build. This version bump will ensure
that the latest version on crates.io can build.
