### PR TITLE
Bump freetype-sys to v0.20.1

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -38,7 +38,7 @@ optional = true
 features = ["dwrite"]
 
 [dependencies.freetype-sys]
-version = "0.19"
+version = "0.20.1"
 optional = true
 
 [features]


### PR DESCRIPTION
Update freetype-sys to v0.20.1 for an OpenHarmony build fix.