### PR TITLE
enable HAVE_FREETYPE when freetype feature is set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "harfbuzz-sys/harfbuzz"]
 	path = harfbuzz-sys/harfbuzz
 	url = https://github.com/harfbuzz/harfbuzz
+[submodule "harfbuzz-sys/freetype-sys"]
+	path = harfbuzz-sys/freetype-sys
+	url = https://github.com/PistonDevelopers/freetype-sys

--- a/harfbuzz-sys/build.rs
+++ b/harfbuzz-sys/build.rs
@@ -17,7 +17,12 @@ fn build_harfbuzz() {
     cfg.cpp(true)
         .flag_if_supported("-std=c++11") // for unix
         .warnings(false)
+        .include("freetype-sys/freetype2/include/")
         .file("harfbuzz/src/harfbuzz.cc");
+
+    if cfg!(feature = "freetype") {
+        cfg.define("HAVE_FREETYPE", "1");
+    }
 
     if !target.contains("windows") {
         cfg.define("HAVE_PTHREAD", "1");


### PR DESCRIPTION
this will caused undefined reference for `hb_ft_font_create_referenced()`, so I patched the lib to properly include freetype when the feature is enabled.