### PR TITLE
Prepare 0.7 release

### DIFF
--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -32,7 +32,7 @@ core-text = { version = "20", optional = true }
 foreign-types = { version = "0.5", optional = true }
 
 [target.'cfg(target_family = "windows")'.dependencies.windows]
-version = "0.59"
+version = "0.62"
 optional = true
 features = ["Win32_Graphics_DirectWrite"]
 

--- a/harfbuzz-sys/Cargo.toml
+++ b/harfbuzz-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz-sys"
-version = "0.6.1"
+version = "0.7.0"
 readme = "README.md"
 categories = ["external-ffi-bindings", "internationalization", "text-processing"]
 description = "Rust bindings to the HarfBuzz text shaping engine"

--- a/harfbuzz/Cargo.toml
+++ b/harfbuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harfbuzz"
-version = "0.6.0"
+version = "0.7.0"
 readme = "README.md"
 description = "High-level Rust bindings to the HarfBuzz text shaping engine"
 
@@ -14,7 +14,7 @@ repository = { workspace = true }
 
 [dependencies.harfbuzz-sys]
 path = "../harfbuzz-sys"
-version = "0.6.1"
+version = "0.7.0"
 default-features = false
 
 [dependencies.harfbuzz-traits]


### PR DESCRIPTION
Features have been renamed, hence a major bump is required.
Required for servo/servo#46233.